### PR TITLE
Added : modelsDir is now optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,15 +21,21 @@ var request = require('superagent');
 var logger = require('./services/logger');
 
 function requireAllModels(Implementation, modelsDir) {
-  return fs.readdirAsync(modelsDir)
-    .each(function (file) {
-      try {
-        require(path.join(modelsDir, file));
-      } catch (e) { }
-    })
-    .then(function () {
-      return _.values(Implementation.getModels());
-    });
+  if (!modelsDir) {
+    //User didn't provide a modelsDir but may already have required them manually
+    //so they might be available
+    return P.resolve(_.values(Implementation.getModels()));
+  } else {
+    return fs.readdirAsync(modelsDir)
+      .each(function (file) {
+        try {
+          require(path.join(modelsDir, file));
+        } catch (e) { }
+      })
+      .then(function () {
+        return _.values(Implementation.getModels());
+      });
+  }
 }
 
 exports.Schemas = Schemas;
@@ -199,7 +205,7 @@ exports.init = function (Implementation) {
   new SessionRoute(app, opts).perform();
 
   //// Init
-  var absModelDirs = path.resolve('.', opts.modelsDir);
+  var absModelDirs = opts.modelsDir ? path.resolve('.', opts.modelsDir) : undefined;
   requireAllModels(Implementation, absModelDirs)
     .then(function (models) {
       return Schemas.perform(Implementation, models, opts)


### PR DESCRIPTION
Since the user can already have registered their models prior to intializing forest, modelsDir must be optional.
In previous implementation, we couldn't provide undefined or null and any dummy value would crash.

Having to provide a valid path (for instance the "root" of the current NodeJS project) was a bad workaround since it would require even non-NodeJS files and would prevent the user from controlling the "require" order.
