### PR TITLE
Use expressMountParent optional setting to mount forest as a subapp

### DIFF
--- a/integrations/stripe/routes.js
+++ b/integrations/stripe/routes.js
@@ -128,31 +128,31 @@ module.exports = function (app, model, Implementation, opts) {
 
   this.perform = function () {
     if (integrationInfo) {
-      app.get('/forest/' + modelName + '_stripe_payments',
+      app.get((opts.expressMountParent ? '/' : '/forest/') + modelName + '_stripe_payments',
         auth.ensureAuthenticated, this.payments);
 
-      app.get('/forest/' + modelName + '/:recordId/stripe_payments',
+      app.get((opts.expressMountParent ? '/' : '/forest/') + modelName + '/:recordId/stripe_payments',
         auth.ensureAuthenticated, this.payments);
 
-      app.post('/forest/' + modelName + '_stripe_payments/refunds',
+      app.post((opts.expressMountParent ? '/' : '/forest/') + modelName + '_stripe_payments/refunds',
         auth.ensureAuthenticated, this.refund);
 
-      app.get('/forest/' + modelName + '_stripe_invoices',
+      app.get((opts.expressMountParent ? '/' : '/forest/') + modelName + '_stripe_invoices',
         auth.ensureAuthenticated, this.invoices);
 
-      app.get('/forest/' + modelName + '/:recordId/stripe_invoices',
+      app.get((opts.expressMountParent ? '/' : '/forest/') + modelName + '/:recordId/stripe_invoices',
         auth.ensureAuthenticated, this.invoices);
 
-      app.get('/forest/' + modelName + '/:recordId/stripe_cards',
+      app.get((opts.expressMountParent ? '/' : '/forest/') + modelName + '/:recordId/stripe_cards',
         auth.ensureAuthenticated, this.cards);
 
-      app.get('/forest/' + modelName + '_stripe_subscriptions',
+      app.get((opts.expressMountParent ? '/' : '/forest/') + modelName + '_stripe_subscriptions',
         auth.ensureAuthenticated, this.subscriptions);
 
-      app.get('/forest/' + modelName + '/:recordId/stripe_subscriptions',
+      app.get((opts.expressMountParent ? '/' : '/forest/') + modelName + '/:recordId/stripe_subscriptions',
         auth.ensureAuthenticated, this.subscriptions);
 
-      app.get('/forest/' + modelName + '/:recordId/stripe_bank_accounts',
+      app.get((opts.expressMountParent ? '/' : '/forest/') + modelName + '/:recordId/stripe_bank_accounts',
         auth.ensureAuthenticated, this.bankAccounts);
     }
   };

--- a/routes/associations.js
+++ b/routes/associations.js
@@ -42,7 +42,7 @@ module.exports = function (app, model, Implementation, opts) {
   }
 
   this.perform = function () {
-    app.get('/forest/' + modelName + '/:recordId/:associationName',
+    app.get((opts.expressMountParent ? '/' : '/forest/') + modelName + '/:recordId/:associationName',
       auth.ensureAuthenticated, index);
   };
 };

--- a/routes/forest.js
+++ b/routes/forest.js
@@ -1,8 +1,8 @@
 'use strict';
 
-module.exports = function (app) {
+module.exports = function (app, opts) {
   this.perform = function () {
-    app.get('/forest', function (req, res) {
+    app.get((opts.expressMountParent ? '/' : '/forest'), function (req, res) {
       res.status(204).send();
     });
   };

--- a/routes/intercom.js
+++ b/routes/intercom.js
@@ -45,10 +45,10 @@ module.exports = function (app, model, Implementation, opts) {
 
   this.perform = function () {
     if (integrationInfo) {
-      app.get('/forest/' + modelName + '/:recordId/intercom_attributes',
+      app.get((opts.expressMountParent ? '/' : '/forest/') + modelName + '/:recordId/intercom_attributes',
         auth.ensureAuthenticated, this.intercomAttributes);
 
-      app.get('/forest/' + modelName + '/:recordId/intercom_conversations',
+      app.get((opts.expressMountParent ? '/' : '/forest/') + modelName + '/:recordId/intercom_conversations',
         auth.ensureAuthenticated, this.intercomConversations);
     }
   };

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -106,18 +106,18 @@ module.exports = function (app, model, Implementation, opts) {
   };
 
   this.perform = function () {
-    app.get('/forest/' + modelName, auth.ensureAuthenticated, this.list);
+    app.get((opts.expressMountParent ? '/' : '/forest/') + modelName, auth.ensureAuthenticated, this.list);
 
-    app.get('/forest/' + modelName + '/:recordId', auth.ensureAuthenticated,
+    app.get((opts.expressMountParent ? '/' : '/forest/') + modelName + '/:recordId', auth.ensureAuthenticated,
       this.get);
 
-    app.post('/forest/' + modelName, auth.ensureAuthenticated,
+    app.post((opts.expressMountParent ? '/' : '/forest/') + modelName, auth.ensureAuthenticated,
       this.create);
 
-    app.put('/forest/' + modelName + '/:recordId', auth.ensureAuthenticated,
+    app.put((opts.expressMountParent ? '/' : '/forest/') + modelName + '/:recordId', auth.ensureAuthenticated,
       this.update);
 
-    app.delete('/forest/' + modelName + '/:recordId', auth.ensureAuthenticated,
+    app.delete((opts.expressMountParent ? '/' : '/forest/') + modelName + '/:recordId', auth.ensureAuthenticated,
       this.remove);
   };
 };

--- a/routes/sessions.js
+++ b/routes/sessions.js
@@ -46,7 +46,7 @@ module.exports = function (app, opts) {
   }
 
   this.perform = function () {
-    app.post('/forest/sessions', login);
+    app.post(opts.expressMountParent ? '/sessions' : '/forest/sessions', login);
   };
 };
 

--- a/routes/stats.js
+++ b/routes/stats.js
@@ -38,7 +38,7 @@ module.exports = function (app, model, Implementation, opts) {
   };
 
   this.perform = function () {
-    app.post('/forest/stats/' + modelName, auth.ensureAuthenticated,
+    app.post((opts.expressMountParent ? '/stats/' : '/forest/stats/') + modelName, auth.ensureAuthenticated,
       this.create);
   };
 };


### PR DESCRIPTION
By default, the express() app used by forest is used as a middleware mounted directly at the root of the parent app :
```
app.use(forestLiana.init({
  modelsDir: __dirname + '/models',  // Your models directory.
  secretKey: 'YOUR-SUPER-SECRET-SECRET-KEY',
  authKey: 'YOUR-SUPER-SECRET-AUTH-KEY', // Choose a secret authentication key.
  ....
}));
```

Forest uses JWT for authentication and relies on `req.user` for the middleware `ensureAuthenticated`

In my case I have other external conditions (like passport) already playing with `req.user`.

In order to keep my REST api (used by my app's frontend) separated from FOREST api, I'd rather use either Express routers or Express sub-apps.

I have quickly refactored the code to show how it could be done.
Instead of mounting all the routes under `/forest/...`, when the option parameter `expressMountParent` is provided, the routes are mounted under `/...` and it's the forest sub-app itself which is mounted under `/forest` in its parent.
This removes for instance the need for the hacky `jwt(...).unless({ path: /^(?!\/forest).*/ })` we see in the code.

In my case my REST api is already in a sub-router under `/api/v1` and I have now moved all `passport` authentication there.
Using forest in it's own sub-app allows for proper separation of duties and avoids middleware clashes.

Here's how I use it : 
```
    var forestLiana = require('forest-express-mongoose');

    var forestApp = forestLiana.init({
        expressMountParent: app,
        secretKey: process.env.FOREST_SECRET,
        authKey: process.env.FOREST_AUTH,
        mongoose: myMongooseRef
    });
```

Feel free to change the name of the setting parameter or other stuff.

I personally wouldn't want to go live in PRODUCTION without such feature.

As a side information, I have tested it with both my frontend and forestadmin without problem and for instance I don't get the DEBUG message anymore from body parser saying `body-parser - body already parsed` since now Forest and my REST api are properly each setting their own.