### PR TITLE
Call next() after all API routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- Smart business logic - Let the developer add a POST hook callback after each API calls.
 
 ## RELEASE 1.0.3 - 2017-03-16
 ### Changed

--- a/routes/associations.js
+++ b/routes/associations.js
@@ -36,7 +36,10 @@ module.exports = function (app, model, Implementation, integrator, opts) {
         return new ResourceSerializer(Implementation, associationModel,
           records, integrator, opts, { count: count }).perform();
       })
-      .then(function (records) { response.send(records); })
+      .then(function (records) {
+        response.send(records);
+        next();
+      })
       .catch(next);
   }
 
@@ -51,7 +54,10 @@ module.exports = function (app, model, Implementation, integrator, opts) {
     return new Implementation.HasManyAssociator(model, associationModel, opts,
       request.params, data)
       .perform()
-      .then(function () { response.status(204).send(); })
+      .then(function () {
+        response.status(204).send();
+        next();
+      })
       .catch(next);
   }
 
@@ -66,7 +72,10 @@ module.exports = function (app, model, Implementation, integrator, opts) {
     return new Implementation.HasManyDissociator(model, associationModel, opts,
       request.params, data)
       .perform()
-      .then(function () { response.status(204).send(); })
+      .then(function () {
+        response.status(204).send();
+        next();
+      })
       .catch(next);
   }
 
@@ -81,7 +90,10 @@ module.exports = function (app, model, Implementation, integrator, opts) {
     return new Implementation.BelongsToUpdater(model, associationModel, opts,
       request.params, data)
       .perform()
-      .then(function () { response.status(204).send(); })
+      .then(function () {
+        response.status(204).send();
+        next();
+      })
       .catch(next);
   }
 

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -45,6 +45,7 @@ module.exports = function (app, model, Implementation, integrator, opts) {
       })
       .then(function (records) {
         res.send(records);
+        next();
       })
       .catch(next);
   };
@@ -58,6 +59,7 @@ module.exports = function (app, model, Implementation, integrator, opts) {
       })
       .then(function (record) {
         res.send(record);
+        next();
       })
       .catch(next);
   };
@@ -75,6 +77,7 @@ module.exports = function (app, model, Implementation, integrator, opts) {
       })
       .then(function (record) {
         res.send(record);
+        next();
       })
       .catch(next);
   };
@@ -91,6 +94,7 @@ module.exports = function (app, model, Implementation, integrator, opts) {
           })
           .then(function (record) {
             res.send(record);
+            next();
             return record;
           })
           .catch(next);
@@ -102,6 +106,7 @@ module.exports = function (app, model, Implementation, integrator, opts) {
       .perform()
       .then(function () {
         res.status(204).send();
+        next();
       })
       .catch(next);
   };

--- a/routes/stats.js
+++ b/routes/stats.js
@@ -34,6 +34,7 @@ module.exports = function (app, model, Implementation, opts) {
       })
       .then(function (stat) {
         res.send(stat);
+        next();
       })
       .catch(next);
   };


### PR DESCRIPTION
@arnaudbesnier We have a customer asking:

```
Is there a way in the node/mongoose integration to perform some business logic AFTER some CRUD operation? For example, sending an email on user creation, only if the user was successfully created. From the documentation around Smart Business Logic, it looks like this can only be achieve by using middleware BEFORE the liana middleware.
```

What do you think about my solution? Just call the next() middleware and let the user define a middleware after the Forest one. Something like:

```
app.use(require('forest-express-mongoose').init({
  modelsDir: __dirname + '/server/models',
  envSecret: process.env.FOREST_ENV_SECRET,
  authSecret: process.env.FOREST_AUTH_SECRET,
  mongoose: require('mongoose')
}));

app.put('/forest/campaigns/:recordId', function (req, res, next) {
  console.log('IT IS CALLED AFTER A SUCCESS UPDATE!');
});
```