### PR TITLE
Prefer intercom access token to  appId/apiKey

### DIFF
--- a/integrations/intercom/services/intercom-attributes-getter.js
+++ b/integrations/intercom/services/intercom-attributes-getter.js
@@ -5,8 +5,7 @@ var useragent = require('useragent');
 function IntercomAttributesGetter(Implementation, params, opts, collectionName) {
   var model = null;
   var Intercom = opts.integrations.intercom.intercom;
-  var intercom = new Intercom.Client(opts.integrations.intercom.appId,
-    opts.integrations.intercom.apiKey).usePromises();
+  var intercom = new Intercom.Client(opts.integrations.intercom.clientOpts).usePromises();
 
   this.perform = function () {
     model = Implementation.getModels()[collectionName];

--- a/integrations/intercom/services/intercom-conversations-getter.js
+++ b/integrations/intercom/services/intercom-conversations-getter.js
@@ -5,8 +5,7 @@ var P = require('bluebird');
 function IntercomConversationsGetter(Implementation, params, opts, collectionName) {
   var model = null;
   var Intercom = opts.integrations.intercom.intercom;
-  var intercom = new Intercom.Client(opts.integrations.intercom.appId,
-    opts.integrations.intercom.apiKey).usePromises();
+  var intercom = new Intercom.Client(opts.integrations.intercom.clientOpts).usePromises();
 
   function hasPagination() {
     return params.page && params.page.number;

--- a/routes/resources.js
+++ b/routes/resources.js
@@ -11,25 +11,6 @@ module.exports = function (app, model, Implementation, integrator, opts) {
   var modelName = Implementation.getModelName(model);
   var schema = Schemas.schemas[Implementation.getModelName(model)];
 
-  function addSmartFields (record) {
-    return P.each(schema.fields, function (field) {
-      if (!record[field.field]) {
-        if (field.value) {
-          var value = field.value(record);
-          if (value && _.isFunction(value.then)) {
-            return value.then(function (value) {
-              record[field.field] = value;
-            });
-          } else {
-            record[field.field] = value;
-          }
-        } else if (_.isArray(field.type)) {
-          record[field.field] = [];
-        }
-      }
-    }).thenReturn(record);
-  }
-
   this.list = function (req, res, next) {
     return new Implementation.ResourcesGetter(model, opts, req.query)
       .perform()
@@ -39,7 +20,24 @@ module.exports = function (app, model, Implementation, integrator, opts) {
 
         // Inject smart fields.
         return P
-          .map(records, addSmartFields)
+          .map(records, function (record) {
+            return P.each(schema.fields, function (field) {
+              if (!record[field.field]) {
+                if (field.value) {
+                  var value = field.value(record);
+                  if (value && _.isFunction(value.then)) {
+                    return value.then(function (value) {
+                      record[field.field] = value;
+                    });
+                  } else {
+                    record[field.field] = value;
+                  }
+                } else if (_.isArray(field.type)) {
+                  record[field.field] = [];
+                }
+              }
+            }).thenReturn(record);
+          })
           .then(function (records) {
             return new ResourceSerializer(Implementation, model, records,
               integrator, opts, { count: count }).perform();
@@ -54,7 +52,6 @@ module.exports = function (app, model, Implementation, integrator, opts) {
   this.get = function (req, res, next) {
     return new Implementation.ResourceGetter(model, req.params)
       .perform()
-      .then(addSmartFields)
       .then(function (record) {
         return new ResourceSerializer(Implementation, model, record,
           integrator, opts).perform();


### PR DESCRIPTION
As noted in #56  As of January 2017 Intercom has deprecated apiKeys and accessKey's must be used (https://developers.intercom.com/docs/personal-access-tokens).  This pull request adds support for using accessTokens but retains support apiKey/appId with a deprecation notice.

I haven't been able to test this end to end with a apiKey/appId since the intercom interface no longer allows you to create one.

Another important note is that the intercom api now requires an "extended" access token to read conversations.  To obtain one of these tokens you must submit a request for the intercom team to review.