### PR TITLE
Only promisify readdir

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var P = require('bluebird');
 var _ = require('lodash');
 var express = require('express');
 var path = require('path');
-var fs = P.promisifyAll(require('fs'));
+var readdirAsync = P.promisify(require('fs').readdir);
 var cors = require('express-cors');
 var bodyParser = require('body-parser');
 var jwt = require('express-jwt');
@@ -21,7 +21,7 @@ var errorHandler = require('./services/error-handler');
 
 function requireAllModels(Implementation, modelsDir) {
   if (modelsDir) {
-    return fs.readdirAsync(modelsDir)
+    return readdirAsync(modelsDir)
       .each(function (file) {
         try {
           require(path.join(modelsDir, file));


### PR DESCRIPTION
I'm currently trying to host my Forest code on Amazon Lambda + API Gateway, using Claudia.js (I'm curious to know if anyone has already tried it).
I have not yet succeeded, but I'll send PRs as I fix the errors I encounter.

The first error that I encountered was with Bluebird. For some reason, when Claudia tries to pack my app and send it to Lambda, `P.promisifyAll(require('fs'));` complains about trying to promisify an async method.

Promisifying only readdir (instead of all of fs) solved it, while also making code initialization more efficient :-)
