### PR TITLE
[-] Performance - Speed up the session response using bcrypt.compare instead of bcrypt.compareSync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- Claudia.js compat - Only promisify fs.readdir
+- Performances - Use async bcrypt.compare instead of bcrypt.compareSync
 
 ## RELEASE 1.0.4 - 2017-03-28
 ### Added

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "main": "index.js",
   "dependencies": {
-    "bcryptjs": "2.3.0",
+    "bcryptjs": "2.4.3",
     "bluebird": "3.3.4",
     "body-parser": "1.15.0",
     "express": "4.14.0",

--- a/routes/sessions.js
+++ b/routes/sessions.js
@@ -12,56 +12,61 @@ module.exports = function (app, opts) {
     new AllowedUsersFinder(request.body.renderingId, opts)
       .perform()
       .then(function (allowedUsers) {
+        if (!opts.authSecret) {
+          throw new Error('Your Forest authSecret seems to be missing. Can ' +
+            'you check that you properly set a Forest authSecret in the ' +
+            'Forest initializer?');
+        }
+
         if (allowedUsers.length === 0) {
-          return response.status(401).send({
-            errors: [{
-              detail: 'Forest cannot retrieve any users for the project ' +
-                'you\'re trying to unlock.'
-            }]
-          });
+          throw new Error('Forest cannot retrieve any users for the project ' +
+            'you\'re trying to unlock.');
         }
 
         var user = _.find(allowedUsers, function (allowedUser) {
-          return allowedUser.email === request.body.email &&
-            bcrypt.compareSync(request.body.password, allowedUser.password);
+          return allowedUser.email === request.body.email;
         });
 
-        if (user) {
-          if (opts.authSecret) {
-            var token = jwt.sign({
-              id: user.id,
-              type: 'users',
-              data: {
-                email: user.email,
-                'first_name': user['first_name'],
-                'last_name': user['last_name'],
-                teams: user.teams
-              },
-              relationships: {
-                renderings: {
-                  data: [{
-                    type: 'renderings',
-                    id: request.body.renderingId
-                  }]
-                }
-              }
-            }, opts.authSecret, {
-              expiresIn: '14 days'
-            });
-
-            response.send({ token: token });
-          } else {
-            return response.status(401).send({
-              errors: [{
-                detail: 'Your Forest authSecret seems to be missing. Can you ' +
-                  'check that you properly set a Forest authSecret in the ' +
-                  'Forest initializer?'
-              }]
-            });
-          }
-        } else {
-          response.status(401).send();
+        if (user === undefined) {
+          throw new Error();
         }
+
+        return bcrypt.compare(request.body.password, user.password)
+          .then(function (isEqual) {
+            if (!isEqual) {
+              throw new Error();
+            }
+            return user;
+          });
+      })
+      .then(function (user) {
+        var token = jwt.sign({
+          id: user.id,
+          type: 'users',
+          data: {
+            email: user.email,
+            'first_name': user['first_name'],
+            'last_name': user['last_name'],
+            teams: user.teams
+          },
+          relationships: {
+            renderings: {
+              data: [{
+                type: 'renderings',
+                id: request.body.renderingId
+              }]
+            }
+          }
+        }, opts.authSecret, {
+          expiresIn: '14 days'
+        });
+
+        response.send({ token: token });
+      })
+      .catch(function (error) {
+        return response.status(401).send({
+          errors: [{ detail: error.message }]
+        });
       });
   }
 


### PR DESCRIPTION
_Continuing my efforts to get Forest to run on Amazon Lambda + API Gateway using Claudia.js_

Amazon Lambda is configured by default to timeout after 3s of execution. Using the basic instance, I could never log into Forest because the limit of 3s was systematically reached. I was able to solve my problem by upgrading my instance (3x CPU and RAM), but I wasn't satisfied with the solution, as only the `/session` calls were causing timeouts, and the rest of the API calls were running fast enough.

After a day of investigation, I figured that `bcrypt.compareSync` was the culprit, and that switching to the async `bcrypt.compare` equivalent resulted in 2x performance improvements (!!), using the same instance.

Here's a screenshot of the logs I get when logging-in 4 times with the `bcrypt.compareSync` version:
![bcrypt-comparesync](https://cloud.githubusercontent.com/assets/39374/24657239/c431bb84-1945-11e7-82b7-b91bfe3c2780.png)

And the same logs using the async `bcrypt.compare` version:
![bcrypt-compare](https://cloud.githubusercontent.com/assets/39374/24657280/e3e2af1a-1945-11e7-9c8c-dd7181b1871a.png)

This PR switches to the async `bcrypt.compare` (and also reorganizes the code a bit to throw as early as possible when `opts.authSecret` isn't configured).

NB: using the native module `bcrypt` isn't an option, as it makes it much harder to deploy on Lambda (the module must be cross-compiled for the target environment).