### PR TITLE
[-] Intercom Integration - Prefer Intercom accessToken configuration to old fashioned appId/apiKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- Intercom Integration - Prefer Intercom accessToken configuration to old fashioned appId/apiKey.
+- Intercom Integration - Remove support for old configuration parameter use "userCollection" (use mapping instead).
 
 ## RELEASE 1.3.0 - 2017-09-20
 ### Added

--- a/integrations/intercom/index.js
+++ b/integrations/intercom/index.js
@@ -107,9 +107,8 @@ function IntercomChecker(opts, Implementation) {
   this.defineFields = function (model, schema) {
     if (!integrationValid) { return; }
 
-    if (integrationCollectionMatch(Implementation, opts.integrations.intercom,
-      model)) {
-        Setup.createFields(Implementation, model, schema.fields);
+    if (integrationCollectionMatch(opts.integrations.intercom, model)) {
+      Setup.createFields(Implementation, model, schema.fields);
     }
   };
 

--- a/integrations/intercom/index.js
+++ b/integrations/intercom/index.js
@@ -75,9 +75,11 @@ function IntercomChecker(opts, Implementation) {
       opts.integrations.intercom.mapping =
         castToArray(opts.integrations.intercom.mapping);
 
-      opts.integrations.intercom.credentials = {
-        token: opts.integrations.intercom.accessToken
-      };
+      if (opts.integrations.intercom.accessToken) {
+        opts.integrations.intercom.credentials = {
+          token: opts.integrations.intercom.accessToken
+        };
+      }
 
       integrationValid = isMappingValid();
     } else {

--- a/integrations/intercom/index.js
+++ b/integrations/intercom/index.js
@@ -12,9 +12,8 @@ function IntercomChecker(opts, Implementation) {
   }
 
   function isProperlyIntegrated() {
-    return opts.integrations.intercom.apiKey &&
-      opts.integrations.intercom.appId && opts.integrations.intercom.intercom &&
-      opts.integrations.intercom.mapping;
+    return opts.integrations.intercom.accessToken &&
+      opts.integrations.intercom.intercom && opts.integrations.intercom.mapping;
   }
 
   function isMappingValid() {
@@ -40,13 +39,11 @@ function IntercomChecker(opts, Implementation) {
     var integrationValid = opts.integrations.intercom.apiKey &&
       opts.integrations.intercom.appId &&
       opts.integrations.intercom.intercom &&
-      opts.integrations.intercom.userCollection;
+      opts.integrations.intercom.mapping;
 
     if (integrationValid) {
-      logger.warn('Intercom integration attribute "userCollection" is now ' +
-        'deprecated, please use "mapping" attribute.');
-      opts.integrations.intercom.mapping =
-        opts.integrations.intercom.userCollection;
+      logger.warn('Intercom integration attributes "apiKey" and "appId" are ' +
+        'now deprecated, please use "accessToken" attribute.');
     }
 
     return integrationValid;
@@ -76,7 +73,12 @@ function IntercomChecker(opts, Implementation) {
   if (hasIntegration()) {
     if (isProperlyIntegrated() || isIntegrationDeprecated()) {
       opts.integrations.intercom.mapping =
-      castToArray(opts.integrations.intercom.mapping);
+        castToArray(opts.integrations.intercom.mapping);
+
+      opts.integrations.intercom.credentials = {
+        token: opts.integrations.intercom.accessToken
+      };
+
       integrationValid = isMappingValid();
     } else {
       logger.error('Cannot setup properly your Intercom integration.');

--- a/integrations/intercom/services/intercom-attributes-getter.js
+++ b/integrations/intercom/services/intercom-attributes-getter.js
@@ -5,8 +5,16 @@ var useragent = require('useragent');
 function IntercomAttributesGetter(Implementation, params, opts, collectionName) {
   var model = null;
   var Intercom = opts.integrations.intercom.intercom;
-  var intercom = new Intercom.Client(opts.integrations.intercom.appId,
-    opts.integrations.intercom.apiKey).usePromises();
+  var intercom;
+
+  if (opts.integrations.intercom.credentials) {
+    intercom = new Intercom.Client(opts.integrations.intercom.credentials)
+      .usePromises();
+  } else {
+    // TODO: Remove once appId/apiKey is not supported anymore.
+    intercom = new Intercom.Client(opts.integrations.intercom.appId,
+      opts.integrations.intercom.apiKey).usePromises();
+  }
 
   this.perform = function () {
     model = Implementation.getModels()[collectionName];

--- a/integrations/intercom/services/intercom-attributes-getter.js
+++ b/integrations/intercom/services/intercom-attributes-getter.js
@@ -60,7 +60,9 @@ function IntercomAttributesGetter(Implementation, params, opts, collectionName) 
           });
       })
       .catch(function (error) {
-        logger.error('Cannot retrieve Intercom attributes for the following reason:', error);
+        if (error.statusCode && error.statusCode !== 404) {
+          logger.error('Cannot retrieve Intercom attributes for the following reason:', error);
+        }
         return null;
       });
   };

--- a/integrations/intercom/services/intercom-attributes-getter.js
+++ b/integrations/intercom/services/intercom-attributes-getter.js
@@ -1,6 +1,7 @@
 'use strict';
 var P = require('bluebird');
 var useragent = require('useragent');
+var logger = require('../../../services/logger');
 
 function IntercomAttributesGetter(Implementation, params, opts, collectionName) {
   var model = null;
@@ -58,7 +59,8 @@ function IntercomAttributesGetter(Implementation, params, opts, collectionName) 
             return user;
           });
       })
-      .catch(function () {
+      .catch(function (error) {
+        logger.error('Cannot retrieve Intercom attributes for the following reason:', error);
         return null;
       });
   };

--- a/integrations/intercom/services/intercom-conversations-getter.js
+++ b/integrations/intercom/services/intercom-conversations-getter.js
@@ -5,8 +5,16 @@ var P = require('bluebird');
 function IntercomConversationsGetter(Implementation, params, opts, collectionName) {
   var model = null;
   var Intercom = opts.integrations.intercom.intercom;
-  var intercom = new Intercom.Client(opts.integrations.intercom.appId,
-    opts.integrations.intercom.apiKey).usePromises();
+  var intercom;
+
+  if (opts.integrations.intercom.credentials) {
+    intercom = new Intercom.Client(opts.integrations.intercom.credentials)
+      .usePromises();
+  } else {
+    // TODO: Remove once appId/apiKey is not supported anymore.
+    intercom = new Intercom.Client(opts.integrations.intercom.appId,
+      opts.integrations.intercom.apiKey).usePromises();
+  }
 
   function hasPagination() {
     return params.page && params.page.number;

--- a/integrations/intercom/setup.js
+++ b/integrations/intercom/setup.js
@@ -6,9 +6,10 @@ var INTEGRATION_NAME = 'intercom';
 exports.createCollections = function (Implementation, apimap, collectionName) {
 
   var collectionDisplayName = _.capitalize(collectionName);
+  var model = Implementation.getModels()[collectionName];
   // jshint camelcase: false
   apimap.push({
-    name: collectionName + '_intercom_conversations',
+    name: Implementation.getModelName(model) + '_intercom_conversations',
     displayName: collectionDisplayName + ' Conversations',
     icon: 'intercom',
     integration: INTEGRATION_NAME,
@@ -25,7 +26,7 @@ exports.createCollections = function (Implementation, apimap, collectionName) {
   });
 
   apimap.push({
-    name: collectionName + '_intercom_attributes',
+    name: Implementation.getModelName(model) + '_intercom_attributes',
     displayName: collectionDisplayName + ' Attributes',
     icon: 'intercom',
     integration: INTEGRATION_NAME,


### PR DESCRIPTION
Fixes: https://github.com/ForestAdmin/forest-express/issues/56

Old integration attributes:
```javascript
app.use(Liana.init({
  // ...
  integrations: {
    intercom: {
      appId: 'YOUR_INTERCOM_APP_ID',
      apiKey: 'YOUR_INTERCOM_API_KEY',
      intercom: require('intercom-client'),
      mapping: 'user'
    }
  }
}));
```

New integration attributes:
```javascript
app.use(Liana.init({
  // ...
  integrations: {
    intercom: {
      accessToken: 'YOUR_INTERCOM_ACCESS_TOKEN',
      intercom: require('intercom-client'),
      mapping: 'user'
    }
  }
}));
```