### PR TITLE
Improve error logging and provide options to bypass Winston

### DIFF
--- a/services/allowed-users-finder.js
+++ b/services/allowed-users-finder.js
@@ -32,7 +32,7 @@ function AllowedUsersFinder(renderingId, opts) {
                 'envSecret in the forest_liana initializer?');
             } else {
               logger.error('Cannot retrieve any users for the project ' +
-                'you\'re trying to unlock. An error occured in Forest API.');
+                'you\'re trying to unlock. An error occured in Forest API.', error);
             }
           }
           resolve(allowedUsers);

--- a/services/error-handler.js
+++ b/services/error-handler.js
@@ -11,7 +11,7 @@ exports.catchIfAny = function (error, request, response, next) {
 
     if (!error.status) {
       // NOTICE: Unexpected errors should log an error in the console.
-      logger.error(message);
+      logger.error(message, error);
     }
     response.status(error.status || 500).send({
       errors: [{

--- a/services/logger.js
+++ b/services/logger.js
@@ -28,8 +28,21 @@ module.exports = new (winston.Logger)({
   transports: [
     new (winston.transports.Console)({
       formatter: function (options) {
-        var message = TITLE + options.message;
-        return winston.config.colorize(options.level, message);
+        var env = process.env;
+        var message = winston.config.colorize(
+          options.level, TITLE + options.message);
+
+        if ( env.NODE_ENV === 'development' || env.FOREST_USE_CONSOLE ) {
+          var level = options.level in console ? options.level : 'log'
+          console[level](message);
+          if ( options.meta && options.meta.stack ) {
+            console[level](options.meta.stack);
+          }
+
+        } else {
+          return message +
+            (options.meta && options.meta.stack ? '\n' + options.meta.stack : '');
+        }
       }
     })
   ],


### PR DESCRIPTION
I've just spent most of my day tracking down another error forest-express was trapping :-)

Usually I go straight to services/error-handler.js and add a `console.error(error)` there, so I have access to the full stack trace.
This time, Forest wasn't displaying any of the smart-fields and smart-segments I had defined in one of my collection in the '/forest' folder, without logging any error to the console, and my usual trick was helpless. It took me quite some time to figure out that requireAllModels was trapping any errors in those files :-(
After that, I searched for a global solution that would allow stack traces to be logged. This proved more difficult than expected, as Winston is a strange beast (that I will personally avoid in libraries I develop): the strings it logs only appear in the terminal, while I only use Chrome's console with Node's `--inspect` flag. I found a solution to log both to Chrome's console and the terminal when in development mode, and log only to the terminal in other cases.

Please let me know if this would work for you :-)