### PR TITLE
[*] Records Serialization - Fix the object types case (kebab case) to prevent potential JSON api adapter errors on client side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Fixed
+- Records Serialization - Fix the object types case (kebab case) to prevent potential JSON api adapter errors on client side.
 
 ## RELEASE 1.1.5 - 2017-06-01
 ### Fixed

--- a/serializers/resource.js
+++ b/serializers/resource.js
@@ -46,9 +46,9 @@ function ResourceSerializer(Implementation, model, records, integrator,
 
             getAttributesFor(dest[field.field], field.type.fields);
           } else if (field.reference) {
-            var referenceType = typeForAttributes[field.field] =
-              field.reference.split('.')[0];
+            var referenceType = field.reference.split('.')[0];
             var referenceSchema = Schemas.schemas[referenceType];
+            typeForAttributes[field.field] = _.kebabCase(referenceType);
 
             dest[fieldName] = {
               ref: referenceSchema.idField,
@@ -108,7 +108,8 @@ function ResourceSerializer(Implementation, model, records, integrator,
       formatDateonly(records);
     }
 
-    return new JSONAPISerializer(schema.name, records, serializationOptions);
+    var typeName = _.kebabCase(schema.name);
+    return new JSONAPISerializer(typeName, records, serializationOptions);
   };
 }
 


### PR DESCRIPTION
Prevent to have JSON API objects having types with camel case (ex: `setupGuide`) that could generate an error on the client. And use kebab case instead (ex: `setup-guide`).