### PR TITLE
Supports collections with name  like 'ACHCredit'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Fixed
+- Serializer - Supports collections with name  like 'ACHCredit'.
 
 ## RELEASE 1.3.2 - 2017-10-02
 ### Fixed

--- a/serializers/resource.js
+++ b/serializers/resource.js
@@ -5,12 +5,6 @@ var JSONAPISerializer = require('jsonapi-serializer').Serializer;
 var Schemas = require('../generators/schemas');
 var logger = require('../services/logger');
 
-function toKebabCase(string) {
-  // NOTICE: Support for the collections beginning with an underscore.
-  if (string[0] === '_') { return '_' + _.kebabCase(string); }
-  return _.kebabCase(string);
-}
-
 function ResourceSerializer(Implementation, model, records, integrator,
   opts, meta) {
   var schema = Schemas.schemas[Implementation.getModelName(model)];
@@ -54,7 +48,7 @@ function ResourceSerializer(Implementation, model, records, integrator,
           } else if (field.reference) {
             var referenceType = field.reference.split('.')[0];
             var referenceSchema = Schemas.schemas[referenceType];
-            typeForAttributes[field.field] = toKebabCase(referenceType);
+            typeForAttributes[field.field] = referenceType;
 
             if (!referenceSchema) {
               logger.error('Cannot find the \'' + referenceType +
@@ -120,8 +114,7 @@ function ResourceSerializer(Implementation, model, records, integrator,
       formatDateonly(records);
     }
 
-    var typeName = toKebabCase(schema.name);
-    return new JSONAPISerializer(typeName, records, serializationOptions);
+    return new JSONAPISerializer(schema.name, records, serializationOptions);
   };
 }
 


### PR DESCRIPTION
## TEST

@arnaudbesnier I've tested with the following collection name and it seems to perfectly works:

- _User
- ACHCredit
- be_RightRoles
- CMMicrositeUser
- ELMAH_Error

![screen shot 2017-10-02 at 14 27 34](https://user-images.githubusercontent.com/519129/31077460-ddb05b84-a77e-11e7-875e-75105165d561.png)
![screen shot 2017-10-02 at 14 27 31](https://user-images.githubusercontent.com/519129/31077462-ddb1e3c8-a77e-11e7-8b2a-78e4a590e4ec.png)
![screen shot 2017-10-02 at 14 27 28](https://user-images.githubusercontent.com/519129/31077461-ddb1e7a6-a77e-11e7-9fa2-e9f32dbd1e55.png)

## SUPPORT
Travelbank needs this.

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request
- [x] Write changes made in the CHANGELOG.md
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code

