### PR TITLE
[*] Initialisation - Prevent bad "import" syntax error detections on initialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Changed
 - Sessions - Display a clean error message if the renderingId and envSecret are missing or inconsistent.
 
+### Fixed
+- Initialisation - Prevent bad "import" syntax error detections on initialisation.
+
 ## RELEASE 1.3.5 - 2017-10-06
 ### Fixed
 - Stripe - Fix the 'mapping' collection name on Express/Mongoose.

--- a/utils/code-syntax-inspector.js
+++ b/utils/code-syntax-inspector.js
@@ -27,7 +27,7 @@ exports.extractCodeSyntaxErrorInDirectoryFile = function (directory) {
       var fileContent = Pfs.readFileSync(file);
 
       try {
-        return esprima.parse(fileContent.toString(), { loc: true });
+        return esprima.parseModule(fileContent.toString(), { loc: true });
       } catch (error) {
         if (error) {
           hasError = true;


### PR DESCRIPTION
Fix: https://github.com/ForestAdmin/forest-express-mongoose/issues/70

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request
- [x] Write changes made in the CHANGELOG.md
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
