### PR TITLE
Sequelize 4 returns date strings not timestamps so don't shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Fixes
+- Records Serialization - Prevent DATEONLY fields being serialized to a daty behind in Sequelize 4 where UTC shift is negative
 
 ## RELEASE 1.5.2 - 2017-11-08
 ### Fixed

--- a/serializers/resource.js
+++ b/serializers/resource.js
@@ -107,11 +107,16 @@ function ResourceSerializer(Implementation, model, records, integrator,
       });
     }
 
+    function isDateOnlyString(field) {
+      return moment(field, 'YYYY-MM-DD', true).isValid();
+    }
+
     function formatFields(record) {
       var offsetServer = moment().utcOffset() / 60;
 
       _.each(fieldNamesDateonly, function (fieldName) {
-        if (record[fieldName]) {
+        //Sequelize 4 returns date strings while 3 returns dateTimeStrings
+        if (record[fieldName] && !isDateOnlyString(record[fieldName])) {
           var dateonly = moment.utc(record[fieldName]).add(offsetServer, 'h');
           record[fieldName] = dateonly.format();
         }


### PR DESCRIPTION
As of Sequelize 4 dateonly fields are returned as date strings not
dateTime strings.  Therefore the formatting functionality here will
return incorrect values for dateonly fields in Sequelize 4 if the server
is in a timezone with a negative UTC shift.

Ex: I have 1990-10-02 stored in my DB.  The formatting function will
shift that to 1990-10-01T16:00:00 if I am in PST.  In the UI 01/10/1990
will be shown

https://github.com/sequelize/sequelize/issues/4858

As a sidenote the existing shifting logic seems backwards to me but it's very possible that I'm missing something.  Let's say I have a DATEONLY value of `1990-10-02` in my db.  My understanding of sequelize 3 is that it will return `1990-10-02T00:00:00z`.  If I have a negative UTC offset it's still going to shift my date back to the wrong day.  I didn't make a change here as I figure I might be missing something.

Accompanying change coming in https://github.com/forestadmin/forest-express-sequelize
