### PR TITLE
Support loading typescript modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- Support loading typescript files
 
 ## RELEASE 2.0.2 - 2017-12-06
 ### Fixed

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function requireAllModels(Implementation, modelsDir, displayMessage) {
     return readdirAsync(modelsDir)
       .each(function (file) {
         try {
-          if (file.endsWith('.js')) {
+          if (file.endsWith('.js') || file.endsWith('.ts')) {
             if (fs.statSync(path.join(modelsDir, file)).isFile()) {
               require(path.join(modelsDir, file));
             }


### PR DESCRIPTION
Hi,

We realized that forest has a hardcoded filter and that it loads only .js files. With this pull request it can also load .ts (TypeScript) files, and therefore can run in a TypeScript environment. 

The change is very simple and should not have any impact on anything else

Thanks