### PR TITLE
[*] TypeScript Support - Fix TypeScript load by not importing declarations

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function requireAllModels(Implementation, modelsDir, displayMessage) {
     return readdirAsync(modelsDir)
       .each(function (file) {
         try {
-          if (file.endsWith('.js') || file.endsWith('.ts')) {
+          if (file.endsWith('.js') || (file.endsWith('.ts') && !file.endsWith('.d.ts')) ) {
             if (fs.statSync(path.join(modelsDir, file)).isFile()) {
               require(path.join(modelsDir, file));
             }


### PR DESCRIPTION
ts support is amazing. But importing *.ts will lead to exceptions on .d.ts declaration files.
is included in the changelog under the current entry for ts support.

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request
- [x] Write changes made in the CHANGELOG.md
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
