### PR TITLE
[*] Smart Actions - Fix custom endpoint route not prefixed correctly

### DIFF
--- a/src/services/path.js
+++ b/src/services/path.js
@@ -5,8 +5,8 @@ exports.generate = (path, options) => {
 
 exports.generateForSmartActionCustomEndpoint = (path, options) => {
   if (options.expressParentApp) {
-    return path.replace(/^\/forest/, '');
+    return path.replace(/^\/forest/, '/');
   }
 
-  return path;
+  return `/${path}`;
 };


### PR DESCRIPTION
Routes generated by `generateForSmartActionCustomEndpoint` are not prefixed with a slash, while they should be, as is the case with `generate`. This broke Smart Actions (filled-in) values for me.

Signed-off-by: Chris Lahaye <dev@chrislahaye.com>
