### PR TITLE
Bugfix: reinitializing liana breaks Forest app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 ### Changed
 - Readme - Add a community section.
+- Fixed a bug where reinitializing the liana would remove collection routes.
 
 ## RELEASE 4.0.0-beta.5 - 2019-08-12
 ### Changed

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,7 @@ exports.ensureAuthenticated = (request, response, next) => {
   auth.authenticate(request, response, next, jwtAuthenticator);
 };
 
-let alreadyInitialized = false;
+let app = null;
 
 function buildSchema(Implementation) {
   const { opts } = Implementation;
@@ -93,14 +93,12 @@ exports.init = (Implementation) => {
     return buildSchema(Implementation).spread(models => models);
   }
 
-  const app = express();
-
-  if (alreadyInitialized) {
+  if (app) {
     logger.warn('Forest init function called more than once. Only the first call has been processed.');
     return app;
   }
 
-  alreadyInitialized = true;
+  app = express();
 
   auth.initAuth(opts);
 


### PR DESCRIPTION
In this PR I've fixed a bug where reinitializing the liana would remove collection routes.

With the existing logic, the first initialization would act normally. The second initialization would set `app` to a bare/empty Express app. This bare app would not match any routes and would return a 404 error for all requests.
We fix this by using memoization to return the already-initialized app if possible.

This bug appears when using Forest admin with AWS Lambda/Serverless/Serverless-offline. Lambda sometimes reuses containers where the code has already been initialized. But we can't make assumptions so we must reinitialize. We were seeing issues where multiple requests would be sent to the Lambda. The first request would succeed, and any following requests would fail because of the reinitialization. 

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request
- [x] Write changes made in the CHANGELOG.md
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
