### PR TITLE
[*] Collections - Fix included/excluded collections not removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 - Intercom Integration - Better handling of automated messages.
+- Collections - Fix included/excluded collections on `Smart Customizations` requireAll call.
 
 ## RELEASE 5.4.1 - 2019-12-11
 ### Fixed

--- a/src/index.js
+++ b/src/index.js
@@ -48,17 +48,29 @@ function getModels() {
   return _.values(models);
 }
 
+function getModelsFileNames() {
+  const models = configStore.Implementation.getModels();
+  const modelsFileNames = [];
+  _.each(models, (modelName) => {
+    modelsFileNames.push(_.kebabCase(modelName));
+  });
+
+  return modelsFileNames;
+}
+
 function requireAllModels(modelsDir) {
   if (modelsDir) {
     try {
+      const modelsFileNames = getModelsFileNames();
       requireAll({
         dirname: modelsDir,
-        filter: (fileName) =>
-          fileName.endsWith('.js') || (fileName.endsWith('.ts') && !fileName.endsWith('.d.ts')),
+        filter: fileName =>
+          (fileName.endsWith('.js') || (fileName.endsWith('.ts') && !fileName.endsWith('.d.ts'))) 
+          && modelsFileNames.includes(fileName.replace(/\.[^/.]+$/, "")),
         recursive: true,
       });
     } catch (error) {
-      logger.error('Cannot read a file for the following reason: ', error);
+      logger.error(`Cannot read a file for the following reason: ${error.message}`, error);
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,7 @@ function requireAllModels(modelsDir) {
         recursive: true,
       });
     } catch (error) {
-      logger.error(`Cannot read a file for the following reason: ${error.message}`, error);
+      logger.error('Cannot read a file for the following reason: ', error);
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -49,24 +49,30 @@ function getModels() {
 }
 
 function getModelsFileNames() {
-  const models = configStore.Implementation.getModels();
-  const modelsFileNames = [];
-  _.each(models, (modelName) => {
-    modelsFileNames.push(_.kebabCase(modelName));
+  const { excludedModels = [], includedModels = [] } = configStore.Implementation.opts;
+  const excludedModelsKebabCase = [];
+  const includedModelsKebabCase = [];
+  _.each(excludedModels, (modelName) => {
+    excludedModelsKebabCase.push(_.kebabCase(modelName));
   });
 
-  return modelsFileNames;
+  _.each(includedModels, (modelName) => {
+    includedModelsKebabCase.push(_.kebabCase(modelName));
+  });
+
+  return { excludedModelsKebabCase, includedModelsKebabCase };
 }
 
 function requireAllModels(modelsDir) {
   if (modelsDir) {
     try {
-      const modelsFileNames = getModelsFileNames();
+      const { excludedModelsKebabCase, includedModelsKebabCase } = getModelsFileNames();
       requireAll({
         dirname: modelsDir,
-        filter: fileName =>
-          (fileName.endsWith('.js') || (fileName.endsWith('.ts') && !fileName.endsWith('.d.ts'))) 
-          && modelsFileNames.includes(fileName.replace(/\.[^/.]+$/, "")),
+        filter: (fileName) =>
+          (fileName.endsWith('.js') || (fileName.endsWith('.ts') && !fileName.endsWith('.d.ts')))
+          && (!excludedModelsKebabCase.includes(fileName.replace(/\.[^/.]+$/, ''))
+             || includedModelsKebabCase.includes(fileName.replace(/\.[^/.]+$/, ''))),
         recursive: true,
       });
     } catch (error) {


### PR DESCRIPTION
## Pull Request checklist:

- [x] Write an explicit title for the Pull Request
- [x] Write changes made in the CHANGELOG.md
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [ ] Wonder if you can improve the existing code

## Steps to Reproduce
Setup a project with lumber and follow the steps of the documentation https://docs.forestadmin.com/documentation/how-tos/include-exclude-models

## Expected behavior
Excluded models should disappear from the UI

## Actual behavior
Excluded models are still present but not accessible

## Corrections
The generation of the `forest` directory was updating the schema with the excluded values (or without the included ones). I added a condition on the `requireAllModels` to ignore (or only take into account) the collections the user wishes to use.