### PR TITLE
[+] Technical - Add sonarJS linter for complexity issues.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,10 @@ module.exports = {
     node: true,
   },
   rules: {
+    'sonarjs/cognitive-complexity': 1,
+    'sonarjs/no-extra-arguments': 0,
+    'sonarjs/no-collapsible-if': 0,
+    'sonarjs/no-identical-expressions': 0,
     'sonarjs/no-identical-functions': 0,
     'sonarjs/no-duplicate-string': 0,
     'sonarjs/no-same-line-conditional': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,16 +12,7 @@ module.exports = {
     node: true,
   },
   rules: {
-    'sonarjs/cognitive-complexity': 1,
-    'sonarjs/no-extra-arguments': 0,
-    'sonarjs/no-collapsible-if': 0,
-    'sonarjs/no-identical-expressions': 0,
-    'sonarjs/no-identical-functions': 0,
-    'sonarjs/no-duplicate-string': 0,
-    'sonarjs/no-same-line-conditional': 0,
     'implicit-arrow-linebreak': 0,
-    'no-param-reassign': 0,
-    'no-underscore-dangle': 0,
     'import/no-extraneous-dependencies': [
       'error',
       {
@@ -32,5 +23,14 @@ module.exports = {
         ]
       }
     ],
+    'no-param-reassign': 0,
+    'no-underscore-dangle': 0,
+    'sonarjs/cognitive-complexity': 1,
+    'sonarjs/no-collapsible-if': 0,
+    'sonarjs/no-duplicate-string': 0,
+    'sonarjs/no-extra-arguments': 0,
+    'sonarjs/no-identical-expressions': 0,
+    'sonarjs/no-identical-functions': 0,
+    'sonarjs/no-same-line-conditional': 0,
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,13 +2,19 @@ module.exports = {
   root: true,
   extends: [
     'airbnb-base',
-    'plugin:jest/all'
+    'plugin:jest/all',
+    'plugin:sonarjs/recommended',
   ],
-  plugins: [],
+  plugins: [
+    'sonarjs',
+  ],
   env: {
     node: true,
   },
   rules: {
+    'sonarjs/no-identical-functions': 0,
+    'sonarjs/no-duplicate-string': 0,
+    'sonarjs/no-same-line-conditional': 0,
     'implicit-arrow-linebreak': 0,
     'no-param-reassign': 0,
     'no-underscore-dangle': 0,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 ### Added
+- Technical - Add SonarJS linter for complexity issues.
 - Tests - Add params fields deserializer test.
 - Tests - Add tests for IP whitelist deserializer.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## [Unreleased]
 ### Added
-- Technical - Add SonarJS linter for complexity issues.
 - Tests - Add params fields deserializer test.
 - Tests - Add tests for IP whitelist deserializer.
+- Technical - Add SonarJS linter for complexity issues.
 
 ### Changed
 - Technical - Simplify IP whitelist deserializer code.

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint-config-airbnb-base": "14.0.0",
     "eslint-plugin-import": "2.18.2",
     "eslint-plugin-jest": "23.0.5",
+    "eslint-plugin-sonarjs": "0.5.0",
     "jest": "24.9.0",
     "nock": "11.7.0",
     "onchange": "6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2305,6 +2305,11 @@ eslint-plugin-jest@23.0.5:
   dependencies:
     "@typescript-eslint/experimental-utils" "^2.5.0"
 
+eslint-plugin-sonarjs@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.5.0.tgz#ce17b2daba65a874c2862213a9e38e8986ad7d7d"
+  integrity sha512-XW5MnzlRjhXpIdbULC/qAdJYHWw3rRLws/DyawdlPU/IdVr9AmRK1r2LaCvabwKOAW2XYYSo3kDX58E4MrB7PQ==
+
 eslint-scope@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"


### PR DESCRIPTION
This PR installs the sonarJS plugin for eslint.
This PR deactivates all sonarJS rules, except the `sonarjs/cognitive-complexity` rule.

The level is set on `1 / warning` to avoid breaking the build.