### PR TITLE
Fix - filter out common test filename patterns when requiring models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
-- Initialization - Filter out test files when requiring models (`__tests__/*`, `*.spec.js`, `*.spec.ts`, `*.test.js` or `*.test.ts`).
+- Initialisation - Filter out test files when requiring models (`__tests__/*`, `*.spec.js`, `*.spec.ts`, `*.test.js` or `*.test.ts`).
 
 ## RELEASE 5.5.0 - 2020-01-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Fixed
+- Initialisation - Do not require files that have `__tests__`, `.test.`, or `.spec.` in their filename.
 
 ## RELEASE 5.5.0 - 2020-01-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 ### Fixed
-- Initialisation - Do not require files that have `__tests__`, `.test.`, or `.spec.` in their filename.
+- Initialization - Filter out test files when requiring models (`__tests__/*`, `*.spec.js`, `*.spec.ts`, `*.test.js` or `*.test.ts`).
 
 ## RELEASE 5.5.0 - 2020-01-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 ### Fixed
 - Linter - Do not lint uncommitted files.
-- Initialisation - Filter out test files when requiring models (`__tests__/*`, `*.spec.js`, `*.spec.ts`, `*.test.js` or `*.test.ts`).
+- Initialization - Filter out test files when requiring models (`__tests__/*`, `*.spec.js`, `*.spec.ts`, `*.test.js` or `*.test.ts`).
 
 ## RELEASE 5.5.0 - 2020-01-02
 ### Added

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,8 @@ function requireAllModels(modelsDir) {
       // NOTICE: Ends with `.spec.js`, `.spec.ts`, `.test.js` or `.test.ts`.
       const isTestFileName = (fileName) => fileName.match(/(?:\.test|\.spec)\.(?:js||ts)$/g);
       requireAll({
-        dirname: modelsDir,
+         dirname: modelsDir,
+         excludeDirs: /^__tests__$/,
         filter: (fileName) => isJSFilename(fileName) && !isTestFilename(fileName),
         recursive: true,
       });

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,8 @@ function requireAllModels(modelsDir) {
   if (modelsDir) {
     try {
       const isJSFilename = (fileName) => fileName.endsWith('.js') || (fileName.endsWith('.ts') && !fileName.endsWith('.d.ts'));
-      const isTestFilename = (fileName) => fileName.match(/__tests__|.test.|.spec./g);
+      // NOTICE: Ends with `.spec.js`, `.spec.ts`, `.test.js` or `.test.ts`.
+      const isTestFileName = (fileName) => fileName.match(/(?:\.test|\.spec)\.(?:js||ts)$/g);
       requireAll({
         dirname: modelsDir,
         filter: (fileName) => isJSFilename(fileName) && !isTestFilename(fileName),

--- a/src/index.js
+++ b/src/index.js
@@ -51,10 +51,11 @@ function getModels() {
 function requireAllModels(modelsDir) {
   if (modelsDir) {
     try {
+      const isJSFilename = (fileName) => fileName.endsWith('.js') || (fileName.endsWith('.ts') && !fileName.endsWith('.d.ts'));
+      const isTestFilename = (fileName) => fileName.match(/__tests__|.test.|.spec./g);
       requireAll({
         dirname: modelsDir,
-        filter: (fileName) =>
-          fileName.endsWith('.js') || (fileName.endsWith('.ts') && !fileName.endsWith('.d.ts')),
+        filter: (fileName) => isJSFilename(fileName) && !isTestFilename(fileName),
         recursive: true,
       });
     } catch (error) {

--- a/src/index.js
+++ b/src/index.js
@@ -51,13 +51,17 @@ function getModels() {
 function requireAllModels(modelsDir) {
   if (modelsDir) {
     try {
-      const isJSFilename = (fileName) => fileName.endsWith('.js') || (fileName.endsWith('.ts') && !fileName.endsWith('.d.ts'));
+      const isJavascriptOrTypescriptFileName = (fileName) =>
+        fileName.endsWith('.js') || (fileName.endsWith('.ts') && !fileName.endsWith('.d.ts'));
+
       // NOTICE: Ends with `.spec.js`, `.spec.ts`, `.test.js` or `.test.ts`.
       const isTestFileName = (fileName) => fileName.match(/(?:\.test|\.spec)\.(?:js||ts)$/g);
+
       requireAll({
-         dirname: modelsDir,
-         excludeDirs: /^__tests__$/,
-        filter: (fileName) => isJSFilename(fileName) && !isTestFilename(fileName),
+        dirname: modelsDir,
+        excludeDirs: /^__tests__$/,
+        filter: (fileName) =>
+          isJavascriptOrTypescriptFileName(fileName) && !isTestFileName(fileName),
         recursive: true,
       });
     } catch (error) {


### PR DESCRIPTION
## Pull Request checklist:

- [x] Write an explicit title for the Pull Request
- [x] Write changes made in the CHANGELOG.md
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code

## Issue
Error thrown on initialisation `ReferenceError: beforeAll is not defined`. `beforeAll` is a Jest function in a file with a path of `db/models/__tests__/*.spec.js`. The stacktrace shows it being required in `requireAllModels`.

## Expected behavior
Forest does not require test files and no error is thrown on initialisation related to Jest functions

## Steps to reproduce:
- Follow the convention of keeping test files with your source files; specifically have one in models directory
- Have that test file call a Jest function such as `beforeAll`
- Observe error thrown when test file is required by Forest during initialisation when models are required


