### PR TITLE
[+] Sessions - Distinguish "CORS configuration issue" and "Server down" scenarios in case of liana login error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 ## [Unreleased]
+### Added
+- Technical - New healthcheck route
+
 ### Fixed
 - Linter - Do not lint uncommitted files.
 - Initialization - Filter out test files when requiring models (`__tests__/*`, `*.spec.js`, `*.spec.ts`, `*.test.js` or `*.test.ts`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 ### Added
-- Technical - New healthcheck route
+- Sessions - Distinguish "CORS configuration issue" and "Server down" scenarios in case of liana login error.
 
 ### Fixed
 - Linter - Do not lint uncommitted files.

--- a/src/index.js
+++ b/src/index.js
@@ -386,4 +386,4 @@ exports.RecordRemover = require('./services/exposed/record-remover');
 exports.RecordSerializer = require('./services/exposed/record-serializer');
 exports.PermissionMiddlewareCreator = require('./middlewares/permissions');
 
-exports.PUBLIC_ROUTES = ['/', '/sessions', '/sessions-google', '/healthcheck'];
+exports.PUBLIC_ROUTES = ['/', '/healthcheck', '/sessions', '/sessions-google'];

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const AssociationsRoutes = require('./routes/associations');
 const StatRoutes = require('./routes/stats');
 const SessionRoute = require('./routes/sessions');
 const ForestRoutes = require('./routes/forest');
+const HealthCheckRoute = require('./routes/healthcheck');
 const Schemas = require('./generators/schemas');
 const SchemaSerializer = require('./serializers/schema');
 const logger = require('./services/logger');
@@ -233,6 +234,7 @@ exports.init = (Implementation) => {
         configStore.lianaOptions,
       ).perform();
     })
+    .then(() => new HealthCheckRoute(app, configStore.lianaOptions).perform())
     .then(() => new ForestRoutes(app, configStore.lianaOptions).perform())
     .then(() => app.use(pathMounted, errorHandler.catchIfAny))
     .then(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -183,6 +183,7 @@ exports.init = (Implementation) => {
   }
 
   new SessionRoute(app, opts).perform();
+  new HealthCheckRoute(app, opts).perform();
 
   // Init
   buildSchema()
@@ -385,4 +386,4 @@ exports.RecordRemover = require('./services/exposed/record-remover');
 exports.RecordSerializer = require('./services/exposed/record-serializer');
 exports.PermissionMiddlewareCreator = require('./middlewares/permissions');
 
-exports.PUBLIC_ROUTES = ['/', '/sessions', '/sessions-google'];
+exports.PUBLIC_ROUTES = ['/', '/sessions', '/sessions-google', '/healthcheck'];

--- a/src/index.js
+++ b/src/index.js
@@ -235,7 +235,6 @@ exports.init = (Implementation) => {
         configStore.lianaOptions,
       ).perform();
     })
-    .then(() => new HealthCheckRoute(app, configStore.lianaOptions).perform())
     .then(() => new ForestRoutes(app, configStore.lianaOptions).perform())
     .then(() => app.use(pathMounted, errorHandler.catchIfAny))
     .then(() => {

--- a/src/index.js
+++ b/src/index.js
@@ -182,8 +182,8 @@ exports.init = (Implementation) => {
     app.use(pathMounted, jwtAuthenticator.unless({ path: pathsPublic }));
   }
 
-  new SessionRoute(app, opts).perform();
   new HealthCheckRoute(app, opts).perform();
+  new SessionRoute(app, opts).perform();
 
   // Init
   buildSchema()

--- a/src/routes/healthcheck.js
+++ b/src/routes/healthcheck.js
@@ -3,7 +3,7 @@ const path = require('../services/path');
 module.exports = function HealthCheck(app, opts) {
   this.perform = () => {
     app.get(path.generate('healthcheck', opts), (request, response) => {
-      response.status(204).send();
+      response.status(200).send();
     });
   };
 };

--- a/src/routes/healthcheck.js
+++ b/src/routes/healthcheck.js
@@ -1,0 +1,9 @@
+const path = require('../services/path');
+
+module.exports = function HealthCheck(app, opts) {
+  this.perform = () => {
+    app.get(path.generate('healthcheck', opts), (request, response) => {
+      response.status(204).send();
+    });
+  };
+};

--- a/src/routes/healthcheck.js
+++ b/src/routes/healthcheck.js
@@ -1,8 +1,9 @@
+const cors = require('cors');
 const path = require('../services/path');
 
 module.exports = function HealthCheck(app, opts) {
   this.perform = () => {
-    app.get(path.generate('healthcheck', opts), (request, response) => {
+    app.get(path.generate('healthcheck', opts), cors(), (request, response) => {
       response.status(200).send();
     });
   };

--- a/test/routes/healthcheck.test.js
+++ b/test/routes/healthcheck.test.js
@@ -6,14 +6,14 @@ const authSecret = Array(65).join('1');
 
 describe('routes > healthcheck', () => {
   describe('#GET /forest/healthcheck', () => {
-    it('should return 204', async () => {
+    it('should return 200', async () => {
       expect.assertions(1);
       const app = createServer(envSecret, authSecret);
       await new Promise((done) => {
         request(app)
           .get('/forest/healthcheck')
           .end((error, response) => {
-            expect(response.status).toStrictEqual(204);
+            expect(response.status).toStrictEqual(200);
             done();
           });
       });

--- a/test/routes/healthcheck.test.js
+++ b/test/routes/healthcheck.test.js
@@ -1,19 +1,21 @@
 const request = require('supertest');
 const createServer = require('../helpers/create-server');
 
+const ACCESS_CONTROL_ALLOW_ORIGIN = 'access-control-allow-origin';
 const envSecret = Array(65).join('0');
 const authSecret = Array(65).join('1');
 
 describe('routes > healthcheck', () => {
   describe('#GET /forest/healthcheck', () => {
     it('should return 200', async () => {
-      expect.assertions(1);
+      expect.assertions(2);
       const app = createServer(envSecret, authSecret);
       await new Promise((done) => {
         request(app)
           .get('/forest/healthcheck')
           .end((error, response) => {
             expect(response.status).toStrictEqual(200);
+            expect(response.res.headers[ACCESS_CONTROL_ALLOW_ORIGIN]).toStrictEqual('*');
             done();
           });
       });

--- a/test/routes/healthcheck.test.js
+++ b/test/routes/healthcheck.test.js
@@ -1,0 +1,22 @@
+const request = require('supertest');
+const createServer = require('../helpers/create-server');
+
+const envSecret = Array(65).join('0');
+const authSecret = Array(65).join('1');
+
+describe('routes > healthcheck', () => {
+  describe('#GET /forest/healthcheck', () => {
+    it('should return 204', async () => {
+      expect.assertions(1);
+      const app = createServer(envSecret, authSecret);
+      await new Promise((done) => {
+        request(app)
+          .get('/forest/healthcheck')
+          .end((error, response) => {
+            expect(response.status).toStrictEqual(204);
+            done();
+          });
+      });
+    });
+  });
+});


### PR DESCRIPTION
This route must: 
respond on /forest/healthcheck
be always reachable (even from different domains)
is used by Liana connection to test if server is on.
It answers 200.

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request
- [x] Write changes made in the CHANGELOG.md
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [ ] Wonder if you can improve the existing code
