### PR TITLE
[*] Schema -  Schemas having fields with escaped characters are now properly saved as valid JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 
 ## [Unreleased]
+### Fixed
+- Schema - Schemas having fields with escaped characters are now properly saved as valid JSON
+- Tests - Add tests for json prettyPrint
+- Tests - Add tests for schema file updater
 
 ## RELEASE 5.6.0 - 2020-01-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## [Unreleased]
 ### Fixed
-- Schema - Schemas having fields with escaped characters are now properly saved as valid JSON
-- Tests - Add tests for json prettyPrint
-- Tests - Add tests for schema file updater
+- Schema - Schemas having fields with escaped characters are now properly saved as valid JSON.
+- Tests - Add tests for json prettyPrint.
+- Tests - Add tests for schema file updater.
 
 ## RELEASE 5.6.0 - 2020-01-14
 ### Added

--- a/src/services/schema-file-updater.js
+++ b/src/services/schema-file-updater.js
@@ -155,10 +155,7 @@ function SchemaFileUpdater(filename, collections, meta, serializerOptions) {
       collection1.name.localeCompare(collection2.name));
 
     const schema = { collections, meta };
-    // NOTICE: Escape '\' characters to ensure the generation of valid JSON files. It fixes
-    //         potential issues if some fields have validations using complex regexp.
-    fs.writeFileSync(filename, prettyPrint(schema)
-      .replace(/[^\\]\\[^\\"]/g, (x) => x.replace('\\', '\\\\')));
+    fs.writeFileSync(filename, prettyPrint(schema));
     return schema;
   };
 }

--- a/src/utils/json.js
+++ b/src/utils/json.js
@@ -44,7 +44,17 @@ const prettyPrint = (json, indentation = '') => {
   } else if (_.isNil(json)) {
     result += 'null';
   } else if (_.isString(json)) {
-    result += `"${json.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\r/g, '\\r').replace(/\n/g, '\\n')}"`;
+    // NOTICE: Escape invalid characters (see: https://www.json.org/json-en.html).
+    const escapedJsonString = json
+      .replace(/[\\]/g, '\\\\')
+      .replace(/["]/g, '\\"')
+      .replace(/[/]/g, '\\/')
+      .replace(/[\b]/g, '\\b')
+      .replace(/[\f]/g, '\\f')
+      .replace(/[\n]/g, '\\n')
+      .replace(/[\r]/g, '\\r')
+      .replace(/[\t]/g, '\\t');
+    result += `"${escapedJsonString}"`;
   } else {
     result += `${json}`;
   }

--- a/src/utils/json.js
+++ b/src/utils/json.js
@@ -44,7 +44,7 @@ const prettyPrint = (json, indentation = '') => {
   } else if (_.isNil(json)) {
     result += 'null';
   } else if (_.isString(json)) {
-    result += `"${json.replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`;
+    result += `"${json.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\r/g, '\\r').replace(/\n/g, '\\n')}"`;
   } else {
     result += `${json}`;
   }

--- a/src/utils/json.js
+++ b/src/utils/json.js
@@ -45,10 +45,11 @@ const prettyPrint = (json, indentation = '') => {
     result += 'null';
   } else if (_.isString(json)) {
     // NOTICE: Escape invalid characters (see: https://www.json.org/json-en.html).
+    //         Also, JSON spec precise that '/' doesn't need to be escaped.
+    //         (see: https://stackoverflow.com/questions/1580647/json-why-are-forward-slashes-escaped)
     const escapedJsonString = json
       .replace(/[\\]/g, '\\\\')
       .replace(/["]/g, '\\"')
-      .replace(/[/]/g, '\\/')
       .replace(/[\b]/g, '\\b')
       .replace(/[\f]/g, '\\f')
       .replace(/[\n]/g, '\\n')

--- a/test/services/schema-file-updater.test.js
+++ b/test/services/schema-file-updater.test.js
@@ -23,7 +23,7 @@ describe('services > schema-file-updater', () => {
   const buildSchema = (collection, metas = meta) =>
     new SchemaFileUpdater('test.json', collection, metas, serializerOptions).perform();
 
-  // NOTICE: Expecting fs.writeFileSync second parameter to be valid JSON
+  // NOTICE: Expecting `fs.writeFileSync` second parameter to be valid JSON.
   it('should call fs.writeFileSync with a valid JSON as data', () => {
     expect.assertions(2);
     buildSchema([], {});

--- a/test/services/schema-file-updater.test.js
+++ b/test/services/schema-file-updater.test.js
@@ -1,0 +1,207 @@
+const fs = require('fs');
+
+const logger = require('../../src/services/logger');
+const SchemaFileUpdater = require('../../src/services/schema-file-updater');
+const SchemaSerializer = require('../../src/serializers/schema');
+
+describe('services > schema-file-updater', () => {
+  const fsWriteFileSyncSpy = jest.spyOn(fs, 'writeFileSync').mockImplementation();
+  const loggerWarnSpy = jest.spyOn(logger, 'warn');
+
+  const meta = {
+    database_type: 'some-db-type',
+    liana: 'some-liana',
+    liana_version: 'some-liana-version',
+    engine: 'some-engine',
+    engine_version: 'some-engine-version',
+    framework: 'some-framework',
+    framework_version: 'some-framework-version',
+    orm_version: 'some-orm-version',
+  };
+  const schemaSerializer = new SchemaSerializer();
+  const { options: serializerOptions } = schemaSerializer;
+  const buildSchema = (collection, metas = meta) =>
+    new SchemaFileUpdater('test.json', collection, metas, serializerOptions).perform();
+
+  // NOTICE: Expecting fs.writeFileSync second parameter to be valid JSON
+  it('should call fs.writeFileSync with a valid JSON as data', () => {
+    expect.assertions(2);
+    buildSchema([], {});
+    expect(fsWriteFileSyncSpy).toHaveBeenCalledTimes(1);
+    const jsonStringSchema = fsWriteFileSyncSpy.mock.calls[0][1];
+    expect(() => JSON.parse(jsonStringSchema)).not.toThrow();
+  });
+
+  it('should format a collection', () => {
+    expect.assertions(1);
+    const schema = buildSchema([{ name: 'collectionName' }], meta);
+    expect(schema.collections[0]).toStrictEqual({
+      name: 'collectionName',
+      nameOld: 'collectionName',
+      icon: null,
+      integration: null,
+      isReadOnly: false,
+      isSearchable: true,
+      isVirtual: false,
+      onlyForRelationships: false,
+      paginationType: 'page',
+      fields: [],
+      segments: [],
+      actions: [],
+    });
+  });
+
+  it('should format field', () => {
+    expect.assertions(2);
+    const schema = buildSchema([{
+      name: 'collectionName',
+      fields: [{
+        field: 'fieldA',
+        defaultValue: 5,
+      }, {
+        field: 'fieldB',
+        validations: [{
+          type: 'is',
+          value: 42,
+        }],
+      }],
+    }]);
+    expect(schema.collections[0].fields[0]).toStrictEqual({
+      field: 'fieldA',
+      type: 'String',
+      defaultValue: 5,
+      enums: null,
+      integration: null,
+      isFilterable: true,
+      isReadOnly: false,
+      isRequired: false,
+      isSortable: true,
+      isVirtual: false,
+      reference: null,
+      inverseOf: null,
+      validations: [],
+    });
+    expect(schema.collections[0].fields[1].validations[0]).toMatchObject({
+      message: null,
+      type: 'is',
+      value: 42,
+    });
+  });
+
+  it('should format action', () => {
+    expect.assertions(2);
+    const schema = buildSchema([{
+      name: 'collectionName',
+      actions: [
+        { name: 'actionName', type: 'notAnExistingType' },
+        {
+          name: 'secondActionName',
+          fields: [{
+            field: 'someOtherField',
+            description: 'This action will \r\n do something',
+            enums: ['yes', 'no'],
+          }],
+        },
+      ],
+    }]);
+    expect(schema.collections[0].actions[0]).toStrictEqual({
+      name: 'actionName',
+      type: null,
+      baseUrl: null,
+      endpoint: '/forest/actions/actionname',
+      httpMethod: 'POST',
+      redirect: null,
+      download: false,
+      fields: [],
+    });
+    expect(schema.collections[0].actions[1].fields[0]).toStrictEqual({
+      field: 'someOtherField',
+      type: 'String',
+      defaultValue: null,
+      enums: ['yes', 'no'],
+      isRequired: false,
+      reference: null,
+      description: 'This action will \r\n do something',
+      position: 0,
+      widget: null,
+    });
+  });
+
+  it('should format segments', () => {
+    expect.assertions(1);
+    const schema = buildSchema([{
+      name: 'collectionName',
+      segments: [{ name: 'segmentName' }],
+    }]);
+    expect(schema.collections[0].segments[0]).toStrictEqual({ name: 'segmentName' });
+  });
+
+  it('should not override existing properties', () => {
+    expect.assertions(1);
+    const schema = buildSchema([{ name: 'collectionName', isVirtual: true }]);
+    expect(schema.collections[0]).toMatchObject({
+      isVirtual: true,
+    });
+  });
+
+  it('should contains meta', () => {
+    expect.assertions(1);
+    const schema = buildSchema([], meta);
+    expect(schema.meta).toStrictEqual(meta);
+  });
+
+  it('should sort collections by name', () => {
+    expect.assertions(2);
+    const schema = buildSchema([{ name: 'collectionZ' }, { name: 'collectionA' }]);
+    expect(schema.collections[0].name).toStrictEqual('collectionA');
+    expect(schema.collections[1].name).toStrictEqual('collectionZ');
+  });
+
+  it('should sort fields by field and type', () => {
+    expect.assertions(3);
+    const schema = buildSchema([{
+      name: 'collectionName',
+      fields: [{ field: 'fieldZ' }, { field: 'fieldA', type: 'Z' }, { field: 'fieldA', type: 'A' }],
+    }]);
+    expect(schema.collections[0].fields[0]).toMatchObject({ field: 'fieldA', type: 'A' });
+    expect(schema.collections[0].fields[1]).toMatchObject({ field: 'fieldA', type: 'Z' });
+    expect(schema.collections[0].fields[2]).toMatchObject({ field: 'fieldZ' });
+  });
+
+  it('should sort actions by name', () => {
+    expect.assertions(2);
+    const schema = buildSchema([{
+      name: 'collectionName',
+      actions: [{ name: 'actionZ' }, { name: 'actionA' }],
+    }]);
+    expect(schema.collections[0].actions[0].name).toStrictEqual('actionA');
+    expect(schema.collections[0].actions[1].name).toStrictEqual('actionZ');
+  });
+
+  it('should set to null invalid action type', () => {
+    expect.assertions(2);
+    const schema = buildSchema([{
+      name: 'collectionName',
+      actions: [
+        { name: 'actionName', type: 'notAnExistingType' },
+      ],
+    }]);
+    expect(schema.collections[0].actions[0].type).toBeNull();
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.stringMatching('Please set a valid Smart Action type'),
+    );
+  });
+
+  it('should log if action.global=true is still used', () => {
+    expect.assertions(1);
+    buildSchema([{
+      name: 'collectionName',
+      actions: [
+        { name: 'actionName', global: true },
+      ],
+    }]);
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.stringMatching('REMOVED OPTION: The support for Smart Action "global" option is now removed'),
+    );
+  });
+});

--- a/test/utils/json.test.js
+++ b/test/utils/json.test.js
@@ -1,0 +1,84 @@
+const { prettyPrint } = require('../../src/utils/json');
+
+describe('utils > json', () => {
+  it('prettyPrint simple primitive types', () => {
+    expect.assertions(5);
+    expect(prettyPrint(1)).toStrictEqual('1');
+    expect(prettyPrint('a simple string')).toStrictEqual('"a simple string"');
+    expect(prettyPrint(true)).toStrictEqual('true');
+
+    expect(prettyPrint(null)).toStrictEqual('null');
+    expect(prettyPrint(undefined)).toStrictEqual('null');
+  });
+
+  it('prettyPrint more complex string', () => {
+    expect.assertions(4);
+    expect(prettyPrint('.*foo$')).toStrictEqual('".*foo$"');
+    expect(prettyPrint('http://somekindofurl.mydomain.com'))
+      .toStrictEqual('"http://somekindofurl.mydomain.com"');
+    expect(prettyPrint('This text \r\n contains \r\n escaped char'))
+      .toStrictEqual('"This text \\r\\n contains \\r\\n escaped char"');
+    expect(prettyPrint('/\r \r\n //"')).toStrictEqual('"/\\r \\r\\n //\\""');
+  });
+
+  it('prettyPrint a simple array', () => {
+    expect.assertions(1);
+    expect(prettyPrint(['a', 'b', 'c'])).toStrictEqual('[\n  "a",\n  "b",\n  "c"\n]');
+  });
+
+  it('prettyPrint a simple object', () => {
+    expect.assertions(1);
+    expect(prettyPrint({ name: 'John' })).toStrictEqual('{\n  "name": "John"\n}');
+  });
+
+  it('prettyPrint a regexp string', () => {
+    expect.assertions(3);
+    const regExp = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/g.toString();
+    const prettyPrintedRegExp = prettyPrint(regExp);
+    // NOTICE: On regex, prettyPrint & JSON.stringify should produce the same result
+    expect(prettyPrintedRegExp).toStrictEqual(JSON.stringify(regExp));
+
+    expect(() => JSON.parse(prettyPrintedRegExp)).not.toThrow();
+    expect(JSON.parse(prettyPrintedRegExp)).toStrictEqual(regExp);
+  });
+
+  it('prettyPrint a simple array of objects', () => {
+    expect.assertions(1);
+    const prettyPrintedObjectArray = prettyPrint([{ name: 'John' }, { name: 'Sylvia' }]);
+
+    expect(prettyPrintedObjectArray)
+      .toStrictEqual('[{\n  "name": "John"\n}, {\n  "name": "Sylvia"\n}]');
+  });
+
+  it('prettyPrint a complex object', () => {
+    expect.assertions(7);
+    const obj = {
+      id: 1,
+      fullname: 'John smith',
+      profile: 'https://mysocialnetwork.mydomain.com/johnsmith',
+      isAvailable: false,
+      extras: {
+        languages: ['js', 'C', 'C++'],
+        caution: '\nw00t//',
+      },
+    };
+    const prettyPrintedObject = prettyPrint(obj);
+
+    expect(prettyPrintedObject)
+      .toStrictEqual(expect.stringContaining('"id": 1,'));
+    expect(prettyPrintedObject)
+      .toStrictEqual(expect.stringContaining('"fullname": "John smith",'));
+    expect(prettyPrintedObject)
+      .toStrictEqual(
+        expect.stringContaining('"profile": "https://mysocialnetwork.mydomain.com/johnsmith",'),
+      );
+    expect(prettyPrintedObject)
+      .toStrictEqual(expect.stringContaining('"isAvailable": false,'));
+    expect(prettyPrintedObject)
+      .toStrictEqual(expect.stringContaining('    "languages": [\n      "js",\n      "C",\n      "C++"\n    ],'));
+    expect(prettyPrintedObject)
+      .toStrictEqual(expect.stringContaining('    "caution": "\\nw00t//"'));
+
+    expect(JSON.parse(prettyPrintedObject)).toStrictEqual(obj);
+  });
+});

--- a/test/utils/json.test.js
+++ b/test/utils/json.test.js
@@ -15,11 +15,11 @@ describe('utils > json', () => {
     expect.assertions(4);
     expect(prettyPrint('.*foo$')).toStrictEqual('".*foo$"');
     expect(prettyPrint('http://somekindofurl.mydomain.com'))
-      .toStrictEqual('"http:\\/\\/somekindofurl.mydomain.com"');
+      .toStrictEqual('"http://somekindofurl.mydomain.com"');
     expect(prettyPrint('This text \r\n contains \r\n escaped char'))
       .toStrictEqual('"This text \\r\\n contains \\r\\n escaped char"');
     expect(prettyPrint('\t \r \n \f \b " /'))
-      .toStrictEqual('"\\t \\r \\n \\f \\b \\" \\/"');
+      .toStrictEqual('"\\t \\r \\n \\f \\b \\" /"');
   });
 
   it('should prettyPrint a simple array', () => {
@@ -37,9 +37,7 @@ describe('utils > json', () => {
     const regExp = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/g.toString();
     const prettyPrintedRegExp = prettyPrint(regExp);
     // NOTICE: On regex, `prettyPrint` & `JSON.stringify` should produce the same result.
-    expect(prettyPrintedRegExp).toStrictEqual(
-      '"\\/^(([^<>()[\\\\]\\\\\\\\.,;:\\\\s@\\"]+(\\\\.[^<>()[\\\\]\\\\\\\\.,;:\\\\s@\\"]+)*)|(\\".+\\"))@((\\\\[[0-9]{1,3}\\\\.[0-9]{1,3}\\\\.[0-9]{1,3}\\\\.[0-9]{1,3}])|(([a-zA-Z\\\\-0-9]+\\\\.)+[a-zA-Z]{2,}))$\\/g"',
-    );
+    expect(prettyPrintedRegExp).toStrictEqual(JSON.stringify(regExp));
     expect(() => JSON.parse(prettyPrintedRegExp)).not.toThrow();
     expect(JSON.parse(prettyPrintedRegExp)).toStrictEqual(regExp);
   });
@@ -72,14 +70,14 @@ describe('utils > json', () => {
       .toStrictEqual(expect.stringContaining('"fullname": "John smith",'));
     expect(prettyPrintedObject)
       .toStrictEqual(
-        expect.stringContaining('"profile": "https:\\/\\/mysocialnetwork.mydomain.com\\/johnsmith",'),
+        expect.stringContaining('"profile": "https://mysocialnetwork.mydomain.com/johnsmith",'),
       );
     expect(prettyPrintedObject)
       .toStrictEqual(expect.stringContaining('"isAvailable": false,'));
     expect(prettyPrintedObject)
       .toStrictEqual(expect.stringContaining('    "languages": [\n      "js",\n      "C",\n      "C++"\n    ],'));
     expect(prettyPrintedObject)
-      .toStrictEqual(expect.stringContaining('    "caution": "\\nw00t\\/\\/"'));
+      .toStrictEqual(expect.stringContaining('    "caution": "\\nw00t//"'));
 
     expect(JSON.parse(prettyPrintedObject)).toStrictEqual(obj);
   });

--- a/test/utils/json.test.js
+++ b/test/utils/json.test.js
@@ -1,7 +1,7 @@
 const { prettyPrint } = require('../../src/utils/json');
 
 describe('utils > json', () => {
-  it('prettyPrint simple primitive types', () => {
+  it('should prettyPrint simple primitive types', () => {
     expect.assertions(5);
     expect(prettyPrint(1)).toStrictEqual('1');
     expect(prettyPrint('a simple string')).toStrictEqual('"a simple string"');
@@ -11,38 +11,40 @@ describe('utils > json', () => {
     expect(prettyPrint(undefined)).toStrictEqual('null');
   });
 
-  it('prettyPrint more complex string', () => {
+  it('should prettyPrint more complex string', () => {
     expect.assertions(4);
     expect(prettyPrint('.*foo$')).toStrictEqual('".*foo$"');
     expect(prettyPrint('http://somekindofurl.mydomain.com'))
-      .toStrictEqual('"http://somekindofurl.mydomain.com"');
+      .toStrictEqual('"http:\\/\\/somekindofurl.mydomain.com"');
     expect(prettyPrint('This text \r\n contains \r\n escaped char'))
       .toStrictEqual('"This text \\r\\n contains \\r\\n escaped char"');
-    expect(prettyPrint('/\r \r\n //"')).toStrictEqual('"/\\r \\r\\n //\\""');
+    expect(prettyPrint('\t \r \n \f \b " /'))
+      .toStrictEqual('"\\t \\r \\n \\f \\b \\" \\/"');
   });
 
-  it('prettyPrint a simple array', () => {
+  it('should prettyPrint a simple array', () => {
     expect.assertions(1);
     expect(prettyPrint(['a', 'b', 'c'])).toStrictEqual('[\n  "a",\n  "b",\n  "c"\n]');
   });
 
-  it('prettyPrint a simple object', () => {
+  it('should prettyPrint a simple object', () => {
     expect.assertions(1);
     expect(prettyPrint({ name: 'John' })).toStrictEqual('{\n  "name": "John"\n}');
   });
 
-  it('prettyPrint a regexp string', () => {
+  it('should prettyPrint a regexp string', () => {
     expect.assertions(3);
     const regExp = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/g.toString();
     const prettyPrintedRegExp = prettyPrint(regExp);
-    // NOTICE: On regex, prettyPrint & JSON.stringify should produce the same result
-    expect(prettyPrintedRegExp).toStrictEqual(JSON.stringify(regExp));
-
+    // NOTICE: On regex, `prettyPrint` & `JSON.stringify` should produce the same result.
+    expect(prettyPrintedRegExp).toStrictEqual(
+      '"\\/^(([^<>()[\\\\]\\\\\\\\.,;:\\\\s@\\"]+(\\\\.[^<>()[\\\\]\\\\\\\\.,;:\\\\s@\\"]+)*)|(\\".+\\"))@((\\\\[[0-9]{1,3}\\\\.[0-9]{1,3}\\\\.[0-9]{1,3}\\\\.[0-9]{1,3}])|(([a-zA-Z\\\\-0-9]+\\\\.)+[a-zA-Z]{2,}))$\\/g"',
+    );
     expect(() => JSON.parse(prettyPrintedRegExp)).not.toThrow();
     expect(JSON.parse(prettyPrintedRegExp)).toStrictEqual(regExp);
   });
 
-  it('prettyPrint a simple array of objects', () => {
+  it('should prettyPrint a simple array of objects', () => {
     expect.assertions(1);
     const prettyPrintedObjectArray = prettyPrint([{ name: 'John' }, { name: 'Sylvia' }]);
 
@@ -50,7 +52,7 @@ describe('utils > json', () => {
       .toStrictEqual('[{\n  "name": "John"\n}, {\n  "name": "Sylvia"\n}]');
   });
 
-  it('prettyPrint a complex object', () => {
+  it('should prettyPrint a complex object', () => {
     expect.assertions(7);
     const obj = {
       id: 1,
@@ -70,14 +72,14 @@ describe('utils > json', () => {
       .toStrictEqual(expect.stringContaining('"fullname": "John smith",'));
     expect(prettyPrintedObject)
       .toStrictEqual(
-        expect.stringContaining('"profile": "https://mysocialnetwork.mydomain.com/johnsmith",'),
+        expect.stringContaining('"profile": "https:\\/\\/mysocialnetwork.mydomain.com\\/johnsmith",'),
       );
     expect(prettyPrintedObject)
       .toStrictEqual(expect.stringContaining('"isAvailable": false,'));
     expect(prettyPrintedObject)
       .toStrictEqual(expect.stringContaining('    "languages": [\n      "js",\n      "C",\n      "C++"\n    ],'));
     expect(prettyPrintedObject)
-      .toStrictEqual(expect.stringContaining('    "caution": "\\nw00t//"'));
+      .toStrictEqual(expect.stringContaining('    "caution": "\\nw00t\\/\\/"'));
 
     expect(JSON.parse(prettyPrintedObject)).toStrictEqual(obj);
   });


### PR DESCRIPTION
Fix \r related issues & add tests

I'm not convinced by the last test of the `json.test.js` because of all the needed whitespaces, which generate ugly string. I did not found a better way to handle those (Since formatting is also a part of the `prettyPrint` function).

I've also tested `schema-file-updater.js` by generating a new lumber project with some regexp validation, which seems to produce a valid `.forestadmin-schema.json`