### PR TITLE
feat(smart actions): add a method to RecordsGetter to get all models IDs given a query or an ID list

### DIFF
--- a/src/deserializers/query.js
+++ b/src/deserializers/query.js
@@ -1,0 +1,9 @@
+function QueryDeserializer(attributes) {
+  this.perform = () => ({
+    ...attributes,
+    areAllRecordsSelected: attributes.are_all_records_selected,
+    excluded_ids: attributes.excluded_ids,
+  });
+}
+
+module.exports = QueryDeserializer;

--- a/src/deserializers/query.js
+++ b/src/deserializers/query.js
@@ -1,10 +1,24 @@
 function QueryDeserializer(attributes) {
-  this.perform = () => ({
-    ...attributes,
-    allRecords: attributes.all_records,
-    allRecordsIdsExcluded: attributes.all_records_ids_excluded,
-    allRecordsSubsetQuery: attributes.all_records_subset_query,
-  });
+  this.perform = () => {
+    const {
+      all_records: allRecords,
+      all_records_ids_excluded: allRecordsIdsExcluded,
+      all_records_subset_query: allRecordsSubsetQuery,
+      parent_association_name: parentAssociationName,
+      parent_collection_name: parentCollectionName,
+      parent_collection_id: parentCollectionId,
+      ...rest
+    } = attributes;
+    return {
+      ...rest,
+      allRecords,
+      allRecordsIdsExcluded,
+      allRecordsSubsetQuery,
+      parentAssociationName,
+      parentCollectionName,
+      parentCollectionId,
+    };
+  };
 }
 
 module.exports = QueryDeserializer;

--- a/src/deserializers/query.js
+++ b/src/deserializers/query.js
@@ -2,7 +2,7 @@ function QueryDeserializer(attributes) {
   this.perform = () => ({
     ...attributes,
     areAllRecordsSelected: attributes.are_all_records_selected,
-    excluded_ids: attributes.excluded_ids,
+    excludedIds: attributes.excluded_ids,
   });
 }
 

--- a/src/deserializers/query.js
+++ b/src/deserializers/query.js
@@ -2,7 +2,7 @@ function QueryDeserializer(attributes) {
   this.perform = () => ({
     ...attributes,
     areAllRecordsSelected: attributes.are_all_records_selected,
-    excludedIds: attributes.excluded_ids,
+    idsExcluded: attributes.ids_excluded,
   });
 }
 

--- a/src/deserializers/query.js
+++ b/src/deserializers/query.js
@@ -1,8 +1,9 @@
 function QueryDeserializer(attributes) {
   this.perform = () => ({
     ...attributes,
-    areAllRecordsSelected: attributes.are_all_records_selected,
-    idsExcluded: attributes.ids_excluded,
+    allRecords: attributes.all_records,
+    allRecordsIdsExcluded: attributes.all_records_ids_excluded,
+    allRecordsSubsetQuery: attributes.all_records_subset_query,
   });
 }
 

--- a/src/routes/associations.js
+++ b/src/routes/associations.js
@@ -129,7 +129,11 @@ module.exports = function Associations(app, model, Implementation, integrator, o
           model,
           associationModel,
           opts,
-          { ...params, ...attributes },
+          {
+            ...params,
+            ...attributes.allRecordsSubsetQuery,
+            page: attributes.page,
+          },
         ).perform();
         return records;
       };

--- a/src/routes/associations.js
+++ b/src/routes/associations.js
@@ -7,7 +7,7 @@ const ResourceSerializer = require('../serializers/resource');
 const Schemas = require('../generators/schemas');
 const CSVExporter = require('../services/csv-exporter');
 const ResourceDeserializer = require('../deserializers/resource');
-const RecordsGetter = require('../services/exposed/records-getter.js');
+const IdsFromRequestRetriever = require('../services/ids-from-request-retriever');
 
 module.exports = function Associations(app, model, Implementation, integrator, opts) {
   const modelName = Implementation.getModelName(model);
@@ -110,29 +110,46 @@ module.exports = function Associations(app, model, Implementation, integrator, o
 
   async function remove(request, response, next) {
     const params = _.extend(request.params, getAssociation(request), request.query);
-
-    let body;
-    // NOTICE: There are two ways to receive request data from frontend:
-    //         - Legacy: `{ body: { data: [ { id: 1, … }, { id: 2, … }, … ]} }`.
-    //         - IDs or query params (similar to smart actions parameters and deletion operations).
-    //
-    //         The HasManyDissociator currently accepts a `data` parameter that has to be formatted
-    //         as the legacy one.
-    const isLegacyRequest = request.body && request.body.data && Array.isArray(request.body.data);
-    if (isLegacyRequest) {
-      body = request.body;
-    } else {
-      const ids = await new RecordsGetter().getIdsFromRequest(request);
-      // NOTICE: Map id list to "body" data parameter (follow legacy body signature).
-      body = { body: ids.map((id) => ({ id })) };
-    }
-
     const models = Implementation.getModels();
     const associationField = getAssociationField(params.associationName);
     const associationModel = _.find(
       models,
       (innerModel) => Implementation.getModelName(innerModel) === associationField,
     );
+
+    let body;
+    // NOTICE: There are three ways to receive request data from frontend:
+    //         - Legacy: `{ body: { data: [ { id: 1, … }, { id: 2, … }, … ]} }`.
+    //         - IDs (select some)
+    //         - Or query params (select all).
+    //
+    //         The HasManyDissociator currently accepts a `data` parameter that has to be formatted
+    //         as the legacy one.
+    const hasBodyAttributes = request.body && request.body.data && request.body.data.attributes;
+    const isLegacyRequest = request.body && request.body.data && Array.isArray(request.body.data);
+    if (!hasBodyAttributes && isLegacyRequest) {
+      body = request.body;
+    } else if (hasBodyAttributes) {
+      const recordsGetter = async (_attributes, currentPageParams) => {
+        const [records] = await new Implementation.HasManyGetter(
+          model,
+          associationModel,
+          opts,
+          { ...params, currentPageParams },
+        ).perform();
+        return records;
+      };
+      const recordsCounter = async () =>
+        new Implementation.HasManyGetter(model, associationModel, opts, params).count();
+      const primaryKeysGetter = () =>
+        Schemas.schemas[Implementation.getModelName(associationModel)];
+      const ids = await new IdsFromRequestRetriever(
+        recordsGetter,
+        recordsCounter,
+        primaryKeysGetter,
+      ).perform(request);
+      body = { body: ids.map((id) => ({ id })) };
+    }
 
     return new Implementation.HasManyDissociator(
       model,

--- a/src/routes/resources.js
+++ b/src/routes/resources.js
@@ -6,6 +6,7 @@ const CSVExporter = require('../services/csv-exporter');
 const ParamsFieldsDeserializer = require('../deserializers/params-fields');
 const PermissionMiddlewareCreator = require('../middlewares/permissions');
 const ConfigStore = require('../services/config-store');
+const RecordsGetter = require('../services/exposed/records-getter.js');
 
 const configStore = ConfigStore.getInstance();
 
@@ -120,6 +121,20 @@ module.exports = function Resources(app, model) {
       .catch(next);
   };
 
+  this.removeMany = async (request, response, next) => {
+    const ids = await new RecordsGetter().getIdsFromRequest(request);
+
+    const promises = ids.map((recordId) =>
+      new Implementation.ResourceRemover(model, { recordId }).perform());
+
+    try {
+      await Promise.all(promises);
+    } catch (e) {
+      next(e);
+    }
+    response.status(204).send();
+  };
+
   const permissionMiddlewareCreator = new PermissionMiddlewareCreator(modelName);
 
   this.perform = () => {
@@ -164,6 +179,12 @@ module.exports = function Resources(app, model) {
       auth.ensureAuthenticated,
       permissionMiddlewareCreator.delete(),
       this.remove,
+    );
+    app.delete(
+      path.generate(modelName, lianaOptions),
+      auth.ensureAuthenticated,
+      permissionMiddlewareCreator.delete(),
+      this.removeMany,
     );
   };
 };

--- a/src/routes/resources.js
+++ b/src/routes/resources.js
@@ -122,7 +122,7 @@ module.exports = function Resources(app, model) {
   };
 
   this.removeMany = async (request, response, next) => {
-    const ids = await new RecordsGetter().getIdsFromRequest(request);
+    const ids = await new RecordsGetter(model).getIdsFromRequest(request);
 
     const promises = ids.map((recordId) =>
       new Implementation.ResourceRemover(model, { recordId }).perform());

--- a/src/routes/resources.js
+++ b/src/routes/resources.js
@@ -124,11 +124,8 @@ module.exports = function Resources(app, model) {
   this.removeMany = async (request, response, next) => {
     const ids = await new RecordsGetter(model).getIdsFromRequest(request);
 
-    const promises = ids.map((recordId) =>
-      new Implementation.ResourceRemover(model, { recordId }).perform());
-
     try {
-      await Promise.all(promises);
+      await new Implementation.ResourcesRemover(model, ids).perform();
     } catch (e) {
       next(e);
     }

--- a/src/services/exposed/records-getter.js
+++ b/src/services/exposed/records-getter.js
@@ -18,8 +18,7 @@ class RecordsGetter extends AbstractRecordService {
   // NOTICE: This function accept either query or ID list params and return an ID list.
   //          It could be used to handle both "select all" (query) and "select some" (ids).
   async getIdsFromRequest(params) {
-    const recordsGetter = async (attributes, currentPageParams) =>
-      this.getAll({ ...attributes, currentPageParams });
+    const recordsGetter = async (attributes) => this.getAll(attributes);
     const recordsCounter = async (attributes) => new this.Implementation.ResourcesGetter(
       this.model,
       this.lianaOptions,

--- a/src/services/exposed/records-getter.js
+++ b/src/services/exposed/records-getter.js
@@ -47,9 +47,9 @@ class RecordsGetter extends AbstractRecordService {
           ...params.query,
           page: { number: `${index + 1}`, size: `${BATCH_PAGE_SIZE}` },
         };
-        const currentRecords = this.getAll(currentRecordsParams).map((record) => getId(record));
+        const currentRecords = await this.getAll(currentRecordsParams);
 
-        return [...await accumulator, ...await currentRecords];
+        return [...await accumulator, ...currentRecords.map((record) => getId(record))];
       }, []);
 
     // NOTICE: remove excluded IDs.

--- a/src/services/exposed/records-getter.js
+++ b/src/services/exposed/records-getter.js
@@ -1,5 +1,8 @@
 const AbstractRecordService = require('./abstract-records-service');
 const ParamsFieldsDeserializer = require('../../deserializers/params-fields');
+const RecordsCounter = require('./records-counter');
+
+const BATCH_PAGE_SIZE = 100;
 
 class RecordsGetter extends AbstractRecordService {
   getAll(params) {
@@ -11,6 +14,26 @@ class RecordsGetter extends AbstractRecordService {
         this.fieldsSearched = fieldsSearched;
         return records;
       });
+  }
+
+  // NOTICE: This function accept either query or body (that contains ID list) params
+  //         and return an ID list. It could be used to handle both "select all" (query)
+  //         and "select some" (ids).
+  async getIdsFromRequest(params) {
+    // NOTICE: If it receives a list of ID, return it as is.
+    if (params.body
+      && params.body.data
+      && params.body.data.attributes
+      && params.body.data.attributes.ids) {
+      return params.body.data.attributes.ids;
+    }
+
+    // NOTICE: records IDs are returned with a batch.
+    const totalRecords = await new RecordsCounter(this.model).count(params.query);
+    return Array.from({ length: totalRecords / BATCH_PAGE_SIZE })
+      .reduce(async (accumulator, _, index) => [...await accumulator, ...(await this.getAll(
+        { ...params.query, page: { number: `${index + 1}`, size: `${BATCH_PAGE_SIZE}` } },
+      )).map((record) => record.id)], []);
   }
 }
 

--- a/src/services/exposed/records-getter.js
+++ b/src/services/exposed/records-getter.js
@@ -59,8 +59,7 @@ class RecordsGetter extends AbstractRecordService {
 
     // NOTICE: remove excluded IDs.
     if (attributes.excludedIds) {
-      const excludedIds = attributes.excludedIds.split(',');
-      return recordsIds.filter((id) => !excludedIds.includes(id));
+      return recordsIds.filter((id) => !attributes.excludedIds.includes(id));
     }
 
     return recordsIds;

--- a/src/services/exposed/records-getter.js
+++ b/src/services/exposed/records-getter.js
@@ -1,5 +1,6 @@
 const AbstractRecordService = require('./abstract-records-service');
 const ParamsFieldsDeserializer = require('../../deserializers/params-fields');
+const QueryDeserializer = require('../../deserializers/query');
 const Schemas = require('../../generators/schemas');
 
 const BATCH_PAGE_SIZE = 100;
@@ -20,9 +21,12 @@ class RecordsGetter extends AbstractRecordService {
   //          It could be used to handle both "select all" (query) and "select some" (ids).
   async getIdsFromRequest(params) {
     const hasBodyAttributes = params.body && params.body.data && params.body.data.attributes;
-    const attributes = hasBodyAttributes && params.body.data.attributes;
+
+    const attributes = hasBodyAttributes
+      && new QueryDeserializer(params.body.data.attributes).perform();
+
     const isSelectAllRecordsQuery = hasBodyAttributes
-      && params.body.data.attributes.areAllRecordsSelected === true;
+      && attributes.areAllRecordsSelected === true;
 
     // NOTICE: If it is not a "select all records" query and it receives a list of ID.
     if (!isSelectAllRecordsQuery && attributes.ids) {

--- a/src/services/exposed/records-getter.js
+++ b/src/services/exposed/records-getter.js
@@ -1,9 +1,7 @@
 const AbstractRecordService = require('./abstract-records-service');
 const ParamsFieldsDeserializer = require('../../deserializers/params-fields');
-const QueryDeserializer = require('../../deserializers/query');
 const Schemas = require('../../generators/schemas');
-
-const BATCH_PAGE_SIZE = 100;
+const IdsFromRequestRetriever = require('../../services/ids-from-request-retriever');
 
 class RecordsGetter extends AbstractRecordService {
   getAll(params) {
@@ -20,49 +18,17 @@ class RecordsGetter extends AbstractRecordService {
   // NOTICE: This function accept either query or ID list params and return an ID list.
   //          It could be used to handle both "select all" (query) and "select some" (ids).
   async getIdsFromRequest(params) {
-    const hasBodyAttributes = params.body && params.body.data && params.body.data.attributes;
-
-    const attributes = hasBodyAttributes
-      && new QueryDeserializer(params.body.data.attributes).perform();
-
-    const isSelectAllRecordsQuery = hasBodyAttributes
-      && attributes.areAllRecordsSelected === true;
-
-    // NOTICE: If it is not a "select all records" query and it receives a list of ID.
-    if (!isSelectAllRecordsQuery && attributes.ids) {
-      return attributes.ids;
-    }
-
-    // NOTICE: Build id from primary keys (there can be multiple primary keys).
-    //         See: https://github.com/ForestAdmin/forest-express-sequelize/blob/42283494de77c9cebe96adbe156caa45c86a80fa/src/services/composite-keys-manager.js#L24-L40
-    const { primaryKeys } = Schemas.schemas[this.Implementation.getModelName(this.model)];
-    const getId = (record) => primaryKeys.map((primaryKey) => record[primaryKey]).join('-');
-
-    // NOTICE: Get records count
-    const recordsCount = await new this.Implementation.ResourcesGetter(
+    const recordsGetter = async (attributes, currentPageParams) =>
+      this.getAll({ ...attributes, currentPageParams });
+    const recordsCounter = async (attributes) => new this.Implementation.ResourcesGetter(
       this.model,
       this.lianaOptions,
       attributes.query,
     ).count(attributes.query);
+    const primaryKeysGetter = () => Schemas.schemas[this.Implementation.getModelName(this.model)];
 
-    // NOTICE: records IDs are returned with a batch.
-    const recordsIds = await Array.from({ length: Math.ceil(recordsCount / BATCH_PAGE_SIZE) })
-      .reduce(async (accumulator, _, index) => {
-        const currentRecordsParams = {
-          ...attributes.query,
-          page: { number: `${index + 1}`, size: `${BATCH_PAGE_SIZE}` },
-        };
-        const currentRecords = await this.getAll(currentRecordsParams);
-
-        return [...await accumulator, ...currentRecords.map((record) => getId(record))];
-      }, []);
-
-    // NOTICE: remove excluded IDs.
-    if (attributes.excludedIds) {
-      return recordsIds.filter((id) => !attributes.excludedIds.includes(id));
-    }
-
-    return recordsIds;
+    return new IdsFromRequestRetriever(recordsGetter, recordsCounter, primaryKeysGetter)
+      .perform(params);
   }
 }
 

--- a/src/services/exposed/records-getter.js
+++ b/src/services/exposed/records-getter.js
@@ -22,8 +22,8 @@ class RecordsGetter extends AbstractRecordService {
     const recordsCounter = async (attributes) => new this.Implementation.ResourcesGetter(
       this.model,
       this.lianaOptions,
-      attributes.query,
-    ).count(attributes.query);
+      attributes.allRecordsSubsetQuery,
+    ).count(attributes.allRecordsSubsetQuery);
     const primaryKeysGetter = () => Schemas.schemas[this.Implementation.getModelName(this.model)];
 
     return new IdsFromRequestRetriever(recordsGetter, recordsCounter, primaryKeysGetter)

--- a/src/services/exposed/records-getter.js
+++ b/src/services/exposed/records-getter.js
@@ -42,9 +42,15 @@ class RecordsGetter extends AbstractRecordService {
 
     // NOTICE: records IDs are returned with a batch.
     const recordsIds = await Array.from({ length: Math.ceil(recordsCount / BATCH_PAGE_SIZE) })
-      .reduce(async (accumulator, _, index) => [...await accumulator, ...(await this.getAll(
-        { ...params.query, page: { number: `${index + 1}`, size: `${BATCH_PAGE_SIZE}` } },
-      )).map((record) => getId(record))], []);
+      .reduce(async (accumulator, _, index) => {
+        const currentRecordsParams = {
+          ...params.query,
+          page: { number: `${index + 1}`, size: `${BATCH_PAGE_SIZE}` },
+        };
+        const currentRecords = this.getAll(currentRecordsParams).map((record) => getId(record));
+
+        return [...await accumulator, ...await currentRecords];
+      }, []);
 
     // NOTICE: remove excluded IDs.
     if (params.query.excludedIds) {

--- a/src/services/exposed/records-getter.js
+++ b/src/services/exposed/records-getter.js
@@ -16,14 +16,52 @@ class RecordsGetter extends AbstractRecordService {
   }
 
   // NOTICE: This function accept either query or ID list params and return an ID list.
-  //          It could be used to handle both "select all" (query) and "select some" (ids).
+  //         It could be used to handle both "select all" (query) and "select some" (ids).
+  //         It also handles related data.
   async getIdsFromRequest(params) {
-    const recordsGetter = async (attributes) => this.getAll(attributes);
-    const recordsCounter = async (attributes) => new this.Implementation.ResourcesGetter(
-      this.model,
-      this.lianaOptions,
-      attributes.allRecordsSubsetQuery,
-    ).count(attributes.allRecordsSubsetQuery);
+    const isRelatedData = (attributes) =>
+      attributes.parentCollectionId
+      && attributes.parentCollectionName
+      && attributes.parentAssociationName;
+
+    const recordsGetter = async (attributes) => {
+      const { parentCollectionId, parentCollectionName, parentAssociationName } = attributes;
+      if (isRelatedData(attributes)) {
+        const parentModel = this.Implementation.getModels()[parentCollectionName];
+        const [records] = await new this.Implementation.HasManyGetter(
+          parentModel,
+          this.model,
+          this.lianaOptions,
+          {
+            ...params,
+            ...attributes.allRecordsSubsetQuery,
+            page: attributes.page,
+            recordId: parentCollectionId,
+            associationName: parentAssociationName,
+          },
+        ).perform();
+        return records;
+      }
+      return this.getAll({ ...attributes.allRecordsSubsetQuery, page: attributes.page });
+    };
+
+    const recordsCounter = async (attributes) => {
+      const { parentCollectionId, parentCollectionName, parentAssociationName } = attributes;
+      if (isRelatedData(attributes)) {
+        const parentModel = this.Implementation.getModels()[parentCollectionName];
+        return new this.Implementation.HasManyGetter(
+          parentModel,
+          this.model,
+          this.lianaOptions,
+          { ...params, recordId: parentCollectionId, associationName: parentAssociationName },
+        ).count();
+      }
+      return new this.Implementation.ResourcesGetter(
+        this.model,
+        this.lianaOptions,
+        attributes.allRecordsSubsetQuery,
+      ).count(attributes.allRecordsSubsetQuery);
+    };
     const primaryKeysGetter = () => Schemas.schemas[this.Implementation.getModelName(this.model)];
 
     return new IdsFromRequestRetriever(recordsGetter, recordsCounter, primaryKeysGetter)

--- a/src/services/exposed/records-getter.js
+++ b/src/services/exposed/records-getter.js
@@ -1,6 +1,6 @@
 const AbstractRecordService = require('./abstract-records-service');
 const ParamsFieldsDeserializer = require('../../deserializers/params-fields');
-const RecordsCounter = require('./records-counter');
+const Schemas = require('../../generators/schemas');
 
 const BATCH_PAGE_SIZE = 100;
 
@@ -20,6 +20,10 @@ class RecordsGetter extends AbstractRecordService {
   //         and return an ID list. It could be used to handle both "select all" (query)
   //         and "select some" (ids).
   async getIdsFromRequest(params) {
+    const getIdField = () => {
+      const schema = Schemas.schemas[this.Implementation.getModelName(this.model)];
+      return schema.primaryKeys[0];
+    };
     // NOTICE: If it receives a list of ID, return it as is.
     if (params.body
       && params.body.data
@@ -29,11 +33,15 @@ class RecordsGetter extends AbstractRecordService {
     }
 
     // NOTICE: records IDs are returned with a batch.
-    const totalRecords = await new RecordsCounter(this.model).count(params.query);
-    return Array.from({ length: totalRecords / BATCH_PAGE_SIZE })
+    const totalRecords = await new this.Implementation.ResourcesGetter(
+      this.model,
+      this.lianaOptions,
+      params,
+    ).count(params.query);
+    return Array.from({ length: Math.ceil(totalRecords / BATCH_PAGE_SIZE) })
       .reduce(async (accumulator, _, index) => [...await accumulator, ...(await this.getAll(
         { ...params.query, page: { number: `${index + 1}`, size: `${BATCH_PAGE_SIZE}` } },
-      )).map((record) => record.id)], []);
+      )).map((record) => record[getIdField()])], []);
   }
 }
 

--- a/src/services/ids-from-request-retriever.js
+++ b/src/services/ids-from-request-retriever.js
@@ -10,7 +10,7 @@ function IdsFromRequestRetriever(recordsGetter, recordsCounter, primaryKeysGette
       && new QueryDeserializer(params.body.data.attributes).perform();
 
     const isSelectAllRecordsQuery = hasBodyAttributes
-      && attributes.areAllRecordsSelected === true;
+      && attributes.allRecords === true;
 
     // NOTICE: If it is not a "select all records" query and it receives a list of ID.
     if (!isSelectAllRecordsQuery && attributes.ids) {
@@ -32,16 +32,16 @@ function IdsFromRequestRetriever(recordsGetter, recordsCounter, primaryKeysGette
     const recordsIds = await Array.from({ length: Math.ceil(recordsCount / BATCH_PAGE_SIZE) })
       .reduce(async (accumulator, _, index) => {
         const currentRecords = await recordsGetter({
-          ...attributes.query,
+          ...attributes.allRecordsSubsetQuery,
           page: { number: `${index + 1}`, size: `${BATCH_PAGE_SIZE}` },
         });
         return [...await accumulator, ...currentRecords.map((record) => getId(record))];
       }, []);
 
     // NOTICE: remove excluded IDs.
-    if (attributes.idsExcluded) {
+    if (attributes.allRecordsIdsExcluded) {
       // NOTICE: Ensure that IDs are comparables (avoid ObjectId or Integer issues).
-      const idsExcludedAsString = attributes.idsExcluded.map(String);
+      const idsExcludedAsString = attributes.allRecordsIdsExcluded.map(String);
       return recordsIds.filter((id) => !idsExcludedAsString.includes(String(id)));
     }
 

--- a/src/services/ids-from-request-retriever.js
+++ b/src/services/ids-from-request-retriever.js
@@ -40,7 +40,9 @@ function IdsFromRequestRetriever(recordsGetter, recordsCounter, primaryKeysGette
 
     // NOTICE: remove excluded IDs.
     if (attributes.idsExcluded) {
-      return recordsIds.filter((id) => !attributes.idsExcluded.includes(id));
+      // NOTICE: Ensure that IDs are comparables (avoid ObjectId or Integer issues).
+      const idsExcludedAsString = attributes.idsExcluded.map(String);
+      return recordsIds.filter((id) => !idsExcludedAsString.includes(String(id)));
     }
 
     return recordsIds;

--- a/src/services/ids-from-request-retriever.js
+++ b/src/services/ids-from-request-retriever.js
@@ -32,7 +32,7 @@ function IdsFromRequestRetriever(recordsGetter, recordsCounter, primaryKeysGette
     const recordsIds = await Array.from({ length: Math.ceil(recordsCount / BATCH_PAGE_SIZE) })
       .reduce(async (accumulator, _, index) => {
         const currentRecords = await recordsGetter({
-          ...attributes.allRecordsSubsetQuery,
+          ...attributes,
           page: { number: `${index + 1}`, size: `${BATCH_PAGE_SIZE}` },
         });
         return [...await accumulator, ...currentRecords.map((record) => getId(record))];

--- a/src/services/ids-from-request-retriever.js
+++ b/src/services/ids-from-request-retriever.js
@@ -39,8 +39,8 @@ function IdsFromRequestRetriever(recordsGetter, recordsCounter, primaryKeysGette
       }, []);
 
     // NOTICE: remove excluded IDs.
-    if (attributes.excludedIds) {
-      return recordsIds.filter((id) => !attributes.excludedIds.includes(id));
+    if (attributes.idsExcluded) {
+      return recordsIds.filter((id) => !attributes.idsExcluded.includes(id));
     }
 
     return recordsIds;

--- a/src/services/ids-from-request-retriever.js
+++ b/src/services/ids-from-request-retriever.js
@@ -20,7 +20,10 @@ function IdsFromRequestRetriever(recordsGetter, recordsCounter, primaryKeysGette
     // NOTICE: Build id from primary keys (there can be multiple primary keys).
     //         See: https://github.com/ForestAdmin/forest-express-sequelize/blob/42283494de77c9cebe96adbe156caa45c86a80fa/src/services/composite-keys-manager.js#L24-L40
     const { primaryKeys } = primaryKeysGetter();
-    const getId = (record) => primaryKeys.map((primaryKey) => record[primaryKey]).join('-');
+    const getId = (record) => (
+      // NOTICE: Primary keys are not available in mongoose schemas.
+      primaryKeys ? primaryKeys.map((primaryKey) => record[primaryKey]).join('-') : record._id
+    );
 
     // NOTICE: Get records count
     const recordsCount = await recordsCounter(attributes);

--- a/src/services/ids-from-request-retriever.js
+++ b/src/services/ids-from-request-retriever.js
@@ -1,0 +1,47 @@
+const QueryDeserializer = require('../deserializers/query');
+
+const BATCH_PAGE_SIZE = 100;
+
+function IdsFromRequestRetriever(recordsGetter, recordsCounter, primaryKeysGetter) {
+  this.perform = async (params) => {
+    const hasBodyAttributes = params.body && params.body.data && params.body.data.attributes;
+
+    const attributes = hasBodyAttributes
+      && new QueryDeserializer(params.body.data.attributes).perform();
+
+    const isSelectAllRecordsQuery = hasBodyAttributes
+      && attributes.areAllRecordsSelected === true;
+
+    // NOTICE: If it is not a "select all records" query and it receives a list of ID.
+    if (!isSelectAllRecordsQuery && attributes.ids) {
+      return attributes.ids;
+    }
+
+    // NOTICE: Build id from primary keys (there can be multiple primary keys).
+    //         See: https://github.com/ForestAdmin/forest-express-sequelize/blob/42283494de77c9cebe96adbe156caa45c86a80fa/src/services/composite-keys-manager.js#L24-L40
+    const { primaryKeys } = primaryKeysGetter();
+    const getId = (record) => primaryKeys.map((primaryKey) => record[primaryKey]).join('-');
+
+    // NOTICE: Get records count
+    const recordsCount = await recordsCounter(attributes);
+
+    // NOTICE: records IDs are returned with a batch.
+    const recordsIds = await Array.from({ length: Math.ceil(recordsCount / BATCH_PAGE_SIZE) })
+      .reduce(async (accumulator, _, index) => {
+        const currentRecords = await recordsGetter({
+          ...attributes.query,
+          page: { number: `${index + 1}`, size: `${BATCH_PAGE_SIZE}` },
+        });
+        return [...await accumulator, ...currentRecords.map((record) => getId(record))];
+      }, []);
+
+    // NOTICE: remove excluded IDs.
+    if (attributes.excludedIds) {
+      return recordsIds.filter((id) => !attributes.excludedIds.includes(id));
+    }
+
+    return recordsIds;
+  };
+}
+
+module.exports = IdsFromRequestRetriever;

--- a/test/services/exposed/records-getter.test.js
+++ b/test/services/exposed/records-getter.test.js
@@ -1,4 +1,25 @@
 const RecordsGetter = require('../../../src/services/exposed/records-getter.js');
+const Schemas = require('../../../src/generators/schemas');
+const usersSchema = require('../../fixtures/users-schema.js');
+
+function getMockedRecordsGetter(modelName = null) {
+  const recordsGetter = new RecordsGetter(modelName);
+  recordsGetter.configStore.Implementation = {
+    ResourcesGetter() {
+      return {
+        perform: () => Promise.resolve([[
+          { id: 1, name: 'foo' },
+          { id: 2, name: 'bar' },
+        ], ['id']]),
+        count: () => 2,
+      };
+    },
+    getModelName(name) {
+      return name;
+    },
+  };
+  return recordsGetter;
+}
 
 describe('services > exposed > records-getter', () => {
   describe('getIdsFromRequest', () => {
@@ -8,6 +29,14 @@ describe('services > exposed > records-getter', () => {
       const request = { body: { data: { attributes: { ids: expectedIds } } } };
       const ids = await new RecordsGetter().getIdsFromRequest(request);
       expect(ids).toBe(expectedIds);
+    });
+    it('should return all entries if query is provided', async () => {
+      expect.assertions(1);
+      Schemas.schemas = { users: usersSchema };
+      const expectedIds = [1, 2];
+      const request = { query: {} };
+      const ids = await getMockedRecordsGetter('users').getIdsFromRequest(request);
+      expect(ids).toStrictEqual(expectedIds);
     });
   });
 });

--- a/test/services/exposed/records-getter.test.js
+++ b/test/services/exposed/records-getter.test.js
@@ -21,7 +21,7 @@ function getMockedRecordsGetter(modelName = null) {
   return recordsGetter;
 }
 
-describe('services > exposed > records-getter', () => {
+describe('services › exposed › records-getter', () => {
   describe('getIdsFromRequest', () => {
     it('should return IDs as is if IDs provided', async () => {
       expect.assertions(1);
@@ -30,13 +30,27 @@ describe('services > exposed > records-getter', () => {
       const ids = await new RecordsGetter().getIdsFromRequest(request);
       expect(ids).toBe(expectedIds);
     });
-    it('should return all entries if query is provided', async () => {
+
+    it('should return all records if query is provided', async () => {
       expect.assertions(1);
       Schemas.schemas = { users: usersSchema };
       const expectedIds = [1, 2];
       const request = { query: {} };
       const ids = await getMockedRecordsGetter('users').getIdsFromRequest(request);
       expect(ids).toStrictEqual(expectedIds);
+    });
+  });
+
+  describe('getAll', () => {
+    it('should return all records', async () => {
+      expect.assertions(1);
+      Schemas.schemas = { users: usersSchema };
+      const expected = [
+        { id: 1, name: 'foo' },
+        { id: 2, name: 'bar' },
+      ];
+      const users = await getMockedRecordsGetter('users').getAll({});
+      expect(users).toStrictEqual(expected);
     });
   });
 });

--- a/test/services/exposed/records-getter.test.js
+++ b/test/services/exposed/records-getter.test.js
@@ -51,7 +51,7 @@ describe('services › exposed › records-getter', () => {
       expect.assertions(1);
       Schemas.schemas = { users: usersSchema };
       const expectedIds = ['2'];
-      const request = bodyDataAttributes({ excluded_ids: ['1', '3'] });
+      const request = bodyDataAttributes({ ids_excluded: ['1', '3'] });
       const ids = await getMockedRecordsGetter('users').getIdsFromRequest(request);
       expect(ids).toStrictEqual(expectedIds);
     });

--- a/test/services/exposed/records-getter.test.js
+++ b/test/services/exposed/records-getter.test.js
@@ -51,7 +51,7 @@ describe('services › exposed › records-getter', () => {
       expect.assertions(1);
       Schemas.schemas = { users: usersSchema };
       const expectedIds = ['2'];
-      const request = bodyDataAttributes({ excludedIds: '1,3' });
+      const request = bodyDataAttributes({ excludedIds: ['1', '3'] });
       const ids = await getMockedRecordsGetter('users').getIdsFromRequest(request);
       expect(ids).toStrictEqual(expectedIds);
     });

--- a/test/services/exposed/records-getter.test.js
+++ b/test/services/exposed/records-getter.test.js
@@ -24,21 +24,25 @@ function getMockedRecordsGetter(modelName = null) {
   return recordsGetter;
 }
 
+function bodyDataAttributes(attributes) {
+  return { body: { data: { attributes } } };
+}
+
 describe('services › exposed › records-getter', () => {
   describe('getIdsFromRequest', () => {
     it('should return IDs as is if IDs provided', async () => {
       expect.assertions(1);
       const expectedIds = ['1', '2'];
-      const request = { body: { data: { attributes: { ids: expectedIds } } } };
+      const request = bodyDataAttributes({ ids: expectedIds });
       const ids = await new RecordsGetter().getIdsFromRequest(request);
       expect(ids).toBe(expectedIds);
     });
 
-    it('should return all records if query is provided', async () => {
+    it('should return all records if areAllRecordsSelected === true', async () => {
       expect.assertions(1);
       Schemas.schemas = { users: usersSchema };
       const expectedIds = ['1', '2', '3'];
-      const request = { query: {} };
+      const request = bodyDataAttributes({ areAllRecordsSelected: true });
       const ids = await getMockedRecordsGetter('users').getIdsFromRequest(request);
       expect(ids).toStrictEqual(expectedIds);
     });
@@ -47,7 +51,7 @@ describe('services › exposed › records-getter', () => {
       expect.assertions(1);
       Schemas.schemas = { users: usersSchema };
       const expectedIds = ['2'];
-      const request = { query: { excludedIds: '1,3' } };
+      const request = bodyDataAttributes({ excludedIds: '1,3' });
       const ids = await getMockedRecordsGetter('users').getIdsFromRequest(request);
       expect(ids).toStrictEqual(expectedIds);
     });

--- a/test/services/exposed/records-getter.test.js
+++ b/test/services/exposed/records-getter.test.js
@@ -42,7 +42,7 @@ describe('services › exposed › records-getter', () => {
       expect.assertions(1);
       Schemas.schemas = { users: usersSchema };
       const expectedIds = ['1', '2', '3'];
-      const request = bodyDataAttributes({ are_all_records_selected: true });
+      const request = bodyDataAttributes({ all_records: true });
       const ids = await getMockedRecordsGetter('users').getIdsFromRequest(request);
       expect(ids).toStrictEqual(expectedIds);
     });
@@ -51,7 +51,7 @@ describe('services › exposed › records-getter', () => {
       expect.assertions(1);
       Schemas.schemas = { users: usersSchema };
       const expectedIds = ['2'];
-      const request = bodyDataAttributes({ ids_excluded: ['1', '3'] });
+      const request = bodyDataAttributes({ all_records_ids_excluded: ['1', '3'] });
       const ids = await getMockedRecordsGetter('users').getIdsFromRequest(request);
       expect(ids).toStrictEqual(expectedIds);
     });

--- a/test/services/exposed/records-getter.test.js
+++ b/test/services/exposed/records-getter.test.js
@@ -1,0 +1,13 @@
+const RecordsGetter = require('../../../src/services/exposed/records-getter.js');
+
+describe('services > exposed > records-getter', () => {
+  describe('getIdsFromRequest', () => {
+    it('should return IDs as is if IDs provided', async () => {
+      expect.assertions(1);
+      const expectedIds = [1, 2, 3];
+      const request = { body: { data: { attributes: { ids: expectedIds } } } };
+      const ids = await new RecordsGetter().getIdsFromRequest(request);
+      expect(ids).toBe(expectedIds);
+    });
+  });
+});

--- a/test/services/exposed/records-getter.test.js
+++ b/test/services/exposed/records-getter.test.js
@@ -42,7 +42,7 @@ describe('services › exposed › records-getter', () => {
       expect.assertions(1);
       Schemas.schemas = { users: usersSchema };
       const expectedIds = ['1', '2', '3'];
-      const request = bodyDataAttributes({ areAllRecordsSelected: true });
+      const request = bodyDataAttributes({ are_all_records_selected: true });
       const ids = await getMockedRecordsGetter('users').getIdsFromRequest(request);
       expect(ids).toStrictEqual(expectedIds);
     });
@@ -51,7 +51,7 @@ describe('services › exposed › records-getter', () => {
       expect.assertions(1);
       Schemas.schemas = { users: usersSchema };
       const expectedIds = ['2'];
-      const request = bodyDataAttributes({ excludedIds: ['1', '3'] });
+      const request = bodyDataAttributes({ excluded_ids: ['1', '3'] });
       const ids = await getMockedRecordsGetter('users').getIdsFromRequest(request);
       expect(ids).toStrictEqual(expectedIds);
     });


### PR DESCRIPTION
BREAKING CHANGE: smart actions must now use this method (documentation has to be updated)

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Test manually the implemented changes
- [x] Add automatic tests
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code

## Description

`RecordsGetter(myModel).getIdsFromRequest(myRequest)` take a `req` object and can handle either a `req.body.data.attributes.ids` (current behavior posted by frontend when selecting some items) or `req.body.data.attributes.query` (just like the current system that request backend with a filter to display in tables views). `excludedIds` can be happened to the actual `req.body.data.attributes` to filter out some IDs (select all but some).

### Usage in smart actions

_don't forget to update documentation after release_

```javascript
// BEFORE:
router.post('/actions/mark-as-live', async (req, res) => {
    let companiesIds = req.body.data.attributes.ids;
    // ...
});

// AFTER:
router.post('/actions/mark-as-live', async (req, res) => {
    let companiesIds = RecordsGetter(companies).getIdsFromRequest(req);
    // ...
});
```

### Delete and dissociate

 - A new route has been added: `DELETE /collection` (without an ID). It works like smart actions (can take either an ID or a query).
 - Relationships dissociation now works with its current behavior (so called "legacy") which is an object list AND the smart action way (you can use both).

## Warning
Don't forget to include the BREAKING CHANGE line in commit message to generate a new version.