### PR TITLE
ci: remove configuration warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
-sudo: required
-
 language: node_js
-
 node_js: lts/*
 
 stages:
@@ -36,7 +33,6 @@ jobs:
       script: skip
       deploy:
         provider: script
-        skip_cleanup: true
         on:
           branch: master
         script:


### PR DESCRIPTION
The warnings we had in Travis:
<img width="743" alt="Screenshot 2020-04-29 at 14 54 53" src="https://user-images.githubusercontent.com/664261/80598533-cd3f6e80-8a29-11ea-9854-b5a46a57d6cf.png">

About `skip_cleanup`:
<img width="661" alt="Screenshot 2020-04-29 at 14 54 34" src="https://user-images.githubusercontent.com/664261/80598582-e1836b80-8a29-11ea-84ea-b79e03cf05f1.png">
(https://blog.travis-ci.com/2019-08-27-deployment-tooling-dpl-v2-preview-release)

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
