### PR TITLE
ci: speed up linting and testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,25 +2,20 @@ language: node_js
 node_js: lts/*
 
 stages:
-  - lint
-  - commit-lint
-  - test
+  - Lint & Tests
   - build
   - publish (dry run)
   - publish
 
 jobs:
   include:
-    # run eslint on all files.
-    - stage: lint
-      script: yarn lint
-    # run tests.
-    - stage: test
-      script: yarn test
-    # devel and master require clean commit messages.
-    - stage: commit-lint
-      if: branch IN ("master", "devel") AND type != pull_request
+    - stage: Lint & Tests
+      name: Lint commit messages
       script: commitlint-travis
+    - script: yarn lint
+      name: Lint JavaScript
+    - script: yarn test
+      name: Tests
     # build only for master and devel (tmp: "improvement/semantic-release").
     - stage: build
       if: branch IN ("master", "devel")


### PR DESCRIPTION
Before: more that 2 minutes (if we also lint commit messages, not included in the screenshot below)
<img width="1279" alt="Screenshot 2020-05-05 at 10 41 02" src="https://user-images.githubusercontent.com/664261/81049751-17f43700-8ebf-11ea-807b-316b4d6054c5.png">

After: 45 seconds
<img width="1282" alt="Screenshot 2020-05-05 at 10 55 40" src="https://user-images.githubusercontent.com/664261/81049711-06129400-8ebf-11ea-97bd-40cab2fc66da.png">

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
