### PR TITLE
fix(record serializer): harmonize the usage of the RecordSerializer

### DIFF
--- a/src/services/exposed/record-serializer.js
+++ b/src/services/exposed/record-serializer.js
@@ -1,6 +1,18 @@
 const AbstractRecordService = require('./abstract-records-service');
 
 class RecordSerializer extends AbstractRecordService {
+  constructor(model) {
+    if (!model) {
+      throw new Error('Missing required parameters `model` passed to constructor');
+    }
+    if (!(model instanceof Object)) {
+      throw new Error('Parameter passed to RecordSerializer constructor should be an object (ex: `{ name: "myModel" }`)');
+    }
+    if (!model.modelName) {
+      model.modelName = model.name;
+    }
+    super(model);
+  }
 }
 
 module.exports = RecordSerializer;

--- a/src/services/exposed/record-serializer.js
+++ b/src/services/exposed/record-serializer.js
@@ -6,7 +6,7 @@ class RecordSerializer extends AbstractRecordService {
       throw new Error('RecordSerializer initialization error: missing first argument "model"');
     }
     if (!(model instanceof Object)) {
-      throw new Error('Parameter passed to RecordSerializer constructor should be an object (ex: `{ name: "myModel" }`)');
+      throw new Error('RecordSerializer initialization error: "model" argument should be an object (ex: `{ name: "myModel" }`)');
     }
     if (!model.modelName) {
       model.modelName = model.name;

--- a/src/services/exposed/record-serializer.js
+++ b/src/services/exposed/record-serializer.js
@@ -3,7 +3,7 @@ const AbstractRecordService = require('./abstract-records-service');
 class RecordSerializer extends AbstractRecordService {
   constructor(model) {
     if (!model) {
-      throw new Error('Missing required parameters `model` passed to constructor');
+      throw new Error('RecordSerializer initialization error: missing first argument "model"');
     }
     if (!(model instanceof Object)) {
       throw new Error('Parameter passed to RecordSerializer constructor should be an object (ex: `{ name: "myModel" }`)');


### PR DESCRIPTION
# Description
The issue is that the `RecordSerializer` usage is different between `forest-express-sequelize` and `forest-express-mongoose`. Especially when used on SmartCollection.

# Current behaviour
```js
// On forest-express-sequelize
const serializer = new RecordSerializer({ name: 'my-smart-collection' });

// On forest-express-mongoose
const serializer = new RecordSerializer({ modelName: 'my-smart-collection' });
```

# With this PR
```js
// Whatever the liana
const serializer = new RecordSerializer({ name: 'my-smart-collection' });
```