### PR TITLE
fix(2FA): throw a clear error when the 2FA salt is invalid

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ const SchemaFileUpdater = require('./services/schema-file-updater');
 const ApimapFieldsFormater = require('./services/apimap-fields-formater');
 const ConfigStore = require('./services/config-store');
 const ProjectDirectoryUtils = require('./utils/project-directory');
+const { is2FASaltValid } = require('./utils/token-checker');
 
 const pathProjectAbsolute = new ProjectDirectoryUtils().getAbsolutePath();
 
@@ -36,6 +37,7 @@ const SCHEMA_FILENAME = `${pathProjectAbsolute}/.forestadmin-schema.json`;
 const DISABLE_AUTO_SCHEMA_APPLY = process.env.FOREST_DISABLE_AUTO_SCHEMA_APPLY
   && JSON.parse(process.env.FOREST_DISABLE_AUTO_SCHEMA_APPLY);
 const REGEX_COOKIE_SESSION_TOKEN = /forest_session_token=([^;]*)/;
+const TWO_FA_SECRET_SALT = process.env.FOREST_2FA_SECRET_SALT;
 const configStore = ConfigStore.getInstance();
 
 let jwtAuthenticator;
@@ -129,6 +131,12 @@ exports.init = (Implementation) => {
     logger.warn('DEPRECATION WARNING: The use of secretKey and authKey options is deprecated. Please use envSecret and authSecret instead.');
     opts.envSecret = opts.secretKey;
     opts.authSecret = opts.authKey;
+  }
+
+  try {
+    is2FASaltValid(TWO_FA_SECRET_SALT);
+  } catch (error) {
+    logger.warn(error.message);
   }
 
   // CORS

--- a/src/services/login-handler.js
+++ b/src/services/login-handler.js
@@ -4,6 +4,7 @@ const logger = require('../services/logger.js');
 const UserSecretCreator = require('./user-secret-creator');
 const AuthorizationFinder = require('./authorization-finder');
 const TwoFactorRegistrationConfirmer = require('../services/two-factor-registration-confirmer');
+const { is2FASaltValid } = require('../utils/token-checker');
 
 function LoginHandler({
   renderingId,
@@ -31,13 +32,10 @@ function LoginHandler({
   function getTwoFactorResponse(user) {
     const TWO_FACTOR_SECRET_SALT = process.env.FOREST_2FA_SECRET_SALT;
 
-    if (TWO_FACTOR_SECRET_SALT === undefined) {
-      logger.error('Cannot use the two factor authentication because the environment variable "FOREST_2FA_SECRET_SALT" is not set.\nYou can generate it using this command: `$ openssl rand -hex 10`');
-      throw new Error('Invalid 2FA configuration, please ask more information to your admin');
-    }
-
-    if (TWO_FACTOR_SECRET_SALT.length !== 20) {
-      logger.error('The FOREST_2FA_SECRET_SALT environment variable must be 20 characters long.\nYou can generate it using this command: `$ openssl rand -hex 10`');
+    try {
+      is2FASaltValid(TWO_FACTOR_SECRET_SALT);
+    } catch (error) {
+      logger.error(error.message);
       throw new Error('Invalid 2FA configuration, please ask more information to your admin');
     }
 

--- a/src/utils/token-checker.js
+++ b/src/utils/token-checker.js
@@ -5,7 +5,7 @@ function is2FASaltValid(token) {
     return true;
   }
 
-  throw new Error('Your 2FA token is invalid. Please use a string of 20 hexadecimal characters. You can generate it using this command: `$ openssl rand -hex 10`');
+  throw new Error('Your 2FA token environment variable "FOREST_2FA_SECRET_SALT" is invalid. Please use a string of 20 hexadecimal characters. You can generate it using this command: `$ openssl rand -hex 10`');
 }
 
 module.exports = {

--- a/src/utils/token-checker.js
+++ b/src/utils/token-checker.js
@@ -1,0 +1,13 @@
+const HEX_20_REGEX = /^[0-9a-f]{20}$/i;
+
+function is2FASaltValid(token) {
+  if (HEX_20_REGEX.test(token)) {
+    return true;
+  }
+
+  throw new Error('You 2FA token is invalid. Please use a string of 20 hexadecimal characters. You can generate it using this command: `$ openssl rand -hex 10`');
+}
+
+module.exports = {
+  is2FASaltValid,
+};

--- a/src/utils/token-checker.js
+++ b/src/utils/token-checker.js
@@ -5,7 +5,7 @@ function is2FASaltValid(token) {
     return true;
   }
 
-  throw new Error('You 2FA token is invalid. Please use a string of 20 hexadecimal characters. You can generate it using this command: `$ openssl rand -hex 10`');
+  throw new Error('Your 2FA token is invalid. Please use a string of 20 hexadecimal characters. You can generate it using this command: `$ openssl rand -hex 10`');
 }
 
 module.exports = {

--- a/test/utils/token-checker.test.js
+++ b/test/utils/token-checker.test.js
@@ -2,7 +2,7 @@ const { is2FASaltValid } = require('../../src/utils/token-checker');
 
 describe('utils > token-checker', () => {
   describe('checking authenticity of 2FA token', () => {
-    const INVALID_2FA_ERROR_MESSAGE = 'You 2FA token is invalid. Please use a string of 20 hexadecimal characters. You can generate it using this command: `$ openssl rand -hex 10`';
+    const INVALID_2FA_ERROR_MESSAGE = 'Your 2FA token is invalid. Please use a string of 20 hexadecimal characters. You can generate it using this command: `$ openssl rand -hex 10`';
 
     it('should return `true`', () => {
       expect.assertions(1);

--- a/test/utils/token-checker.test.js
+++ b/test/utils/token-checker.test.js
@@ -4,7 +4,7 @@ describe('utils > token-checker', () => {
   describe('checking authenticity of 2FA token', () => {
     const INVALID_2FA_ERROR_MESSAGE = 'Your 2FA token is invalid. Please use a string of 20 hexadecimal characters. You can generate it using this command: `$ openssl rand -hex 10`';
 
-    it('should return `true`', () => {
+    it('should return `true` if the token is valid', () => {
       expect.assertions(1);
       expect(is2FASaltValid('b95be26591747d670891')).toStrictEqual(true);
     });

--- a/test/utils/token-checker.test.js
+++ b/test/utils/token-checker.test.js
@@ -2,7 +2,7 @@ const { is2FASaltValid } = require('../../src/utils/token-checker');
 
 describe('utils > token-checker', () => {
   describe('checking authenticity of 2FA token', () => {
-    const INVALID_2FA_ERROR_MESSAGE = 'Your 2FA token is invalid. Please use a string of 20 hexadecimal characters. You can generate it using this command: `$ openssl rand -hex 10`';
+    const INVALID_2FA_ERROR_MESSAGE = 'Your 2FA token environment variable "FOREST_2FA_SECRET_SALT" is invalid. Please use a string of 20 hexadecimal characters. You can generate it using this command: `$ openssl rand -hex 10`';
 
     it('should return `true` if the token is valid', () => {
       expect.assertions(1);

--- a/test/utils/token-checker.test.js
+++ b/test/utils/token-checker.test.js
@@ -1,0 +1,29 @@
+const { is2FASaltValid } = require('../../src/utils/token-checker');
+
+describe('utils > token-checker', () => {
+  describe('checking authenticity of 2FA token', () => {
+    const INVALID_2FA_ERROR_MESSAGE = 'You 2FA token is invalid. Please use a string of 20 hexadecimal characters. You can generate it using this command: `$ openssl rand -hex 10`';
+
+    it('should return `true`', () => {
+      expect.assertions(1);
+      expect(is2FASaltValid('b95be26591747d670891')).toStrictEqual(true);
+    });
+
+    it('should throw an error if the token is empty', () => {
+      expect.assertions(3);
+      expect(() => is2FASaltValid(undefined)).toThrow(INVALID_2FA_ERROR_MESSAGE);
+      expect(() => is2FASaltValid(null)).toThrow(INVALID_2FA_ERROR_MESSAGE);
+      expect(() => is2FASaltValid('')).toThrow(INVALID_2FA_ERROR_MESSAGE);
+    });
+
+    it('should throw an error if the token is not 20 characters long', () => {
+      expect.assertions(1);
+      expect(() => is2FASaltValid('1234')).toThrow(INVALID_2FA_ERROR_MESSAGE);
+    });
+
+    it('should throw an error if the token is not composed of hexadecimal characters only', () => {
+      expect.assertions(1);
+      expect(() => is2FASaltValid('NOTHEXADECIMAL123456')).toThrow(INVALID_2FA_ERROR_MESSAGE);
+    });
+  });
+});


### PR DESCRIPTION
## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
- [x] Add tests

[ClickUp](https://app.clickup.com/t/6mv6jr)

🚧 To test it, add FOREST_2FA_SECRET_SALT as an environment variable, and set it to a wrong value (or either a null value). If you start you server, you should see a log message stating that your token is not valid. Going further, if you try to login by using the 2FA flow, you should see an error on your web app.

A value is considered as wrong if the string is not 20 characters long, and if it is not composed of hexadecimal characters only. 

If you set a correct token, you should not see any error message (either on your server, and the web app) 🚧 