### PR TITLE
fix(integration): prevent 500 errors if Intercom record is not found

### DIFF
--- a/src/integrations/intercom/services/attributes-getter.js
+++ b/src/integrations/intercom/services/attributes-getter.js
@@ -10,8 +10,13 @@ function AttributesGetter(Implementation, params, opts, mappingValue) {
       const contactQueryResponse = await ContactGetter
         .getContact(intercom, Implementation, mappingValue, params.recordId);
 
-      // NOTICE: No contact find with the given `recordId` or `mappingValue`
-      if (!contactQueryResponse || !contactQueryResponse.body || !contactQueryResponse.body.data) {
+      // NOTICE: No contact found with the given `recordId` or `mappingValue`
+      if (
+        !contactQueryResponse
+        || !contactQueryResponse.body
+        || !contactQueryResponse.body.data
+        || !contactQueryResponse.body.data[0]
+      ) {
         return null;
       }
 

--- a/src/integrations/intercom/services/attributes-getter.js
+++ b/src/integrations/intercom/services/attributes-getter.js
@@ -17,6 +17,7 @@ function AttributesGetter(Implementation, params, opts, mappingValue) {
         || !contactQueryResponse.body.data
         || !contactQueryResponse.body.data[0]
       ) {
+        logger.error('Cannot access to Intercom attributes: No intercom contact matches the given key');
         return null;
       }
 


### PR DESCRIPTION
This returns `null` if no contact is found in Intercom response body.

Returning `null` complies with current behaviour for other requests. Returning a 404 error is not properly handled by the admin interface for the time beeing.

Linked to: CU-6mqmhe

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Test manually the implemented changes
- [ ] Review my own code (indentation, syntax, style, simplicity, readability)
- [ ] Wonder if you can improve the existing code
