### PR TITLE
feat(absoluterootpath): add the option to pass the root path

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,11 +30,8 @@ const ProjectDirectoryUtils = require('./utils/project-directory');
 const { is2FASaltValid } = require('./utils/token-checker');
 const { getJWTConfiguration } = require('./config/jwt');
 
-const pathProjectAbsolute = new ProjectDirectoryUtils().getAbsolutePath();
-
 const ENVIRONMENT_DEVELOPMENT = !process.env.NODE_ENV
   || ['dev', 'development'].includes(process.env.NODE_ENV);
-const SCHEMA_FILENAME = `${pathProjectAbsolute}/.forestadmin-schema.json`;
 const DISABLE_AUTO_SCHEMA_APPLY = process.env.FOREST_DISABLE_AUTO_SCHEMA_APPLY
   && JSON.parse(process.env.FOREST_DISABLE_AUTO_SCHEMA_APPLY);
 const REGEX_COOKIE_SESSION_TOKEN = /forest_session_token=([^;]*)/;
@@ -113,6 +110,8 @@ exports.init = (Implementation) => {
 
   configStore.Implementation = Implementation;
   configStore.lianaOptions = opts;
+
+  const schemaFileName = path.join(opts.absoluteRootPath || new ProjectDirectoryUtils().getAbsolutePath(), '.forestadmin-schema.json');
 
   if (opts.onlyCrudModule === true) {
     return buildSchema();
@@ -291,13 +290,13 @@ exports.init = (Implementation) => {
           framework_version: expressVersion,
           orm_version: configStore.Implementation.getOrmVersion(),
         };
-        const content = new SchemaFileUpdater(SCHEMA_FILENAME, collections, meta, serializerOptions)
+        const content = new SchemaFileUpdater(schemaFileName, collections, meta, serializerOptions)
           .perform();
         collectionsSent = content.collections;
         metaSent = content.meta;
       } else {
         try {
-          const content = fs.readFileSync(SCHEMA_FILENAME);
+          const content = fs.readFileSync(schemaFileName);
           if (!content) {
             logger.error('The .forestadmin-schema.json file is empty.');
             logger.error('The schema cannot be synchronized with Forest Admin servers.');


### PR DESCRIPTION
Fixes #445 

Yarn v2 sets the project dependencies in zip files in a .yarn directory. Instead of handling yarn v2 specific case, why not allow everyone to set the root directory they want to use? It would allow everyone to choose where the schema is stored.

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
