### PR TITLE
fix: don't compute smart fields when not requested on associated records

### DIFF
--- a/src/routes/associations.js
+++ b/src/routes/associations.js
@@ -8,6 +8,7 @@ const Schemas = require('../generators/schemas');
 const CSVExporter = require('../services/csv-exporter');
 const ResourceDeserializer = require('../deserializers/resource');
 const IdsFromRequestRetriever = require('../services/ids-from-request-retriever');
+const ParamsFieldsDeserializer = require('../deserializers/params-fields');
 
 module.exports = function Associations(app, model, Implementation, integrator, opts) {
   const modelName = Implementation.getModelName(model);
@@ -47,6 +48,7 @@ module.exports = function Associations(app, model, Implementation, integrator, o
 
   function list(request, response, next) {
     const { params, associationModel } = getContext(request);
+    const fieldsPerModel = new ParamsFieldsDeserializer(params.fields).perform();
 
     return new Implementation.HasManyGetter(model, associationModel, opts, params)
       .perform()
@@ -58,6 +60,7 @@ module.exports = function Associations(app, model, Implementation, integrator, o
         null,
         fieldsSearched,
         params.search,
+        fieldsPerModel,
       ).perform())
       .then((records) => response.send(records))
       .catch(next);


### PR DESCRIPTION
Linked to CU-a2z7p8

I don't see how to test this modification either with unit tests or integration tests with the current architecture of `forest-express`.

## Pull Request checklist:

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Test manually the implemented changes
- [ ] Review my own code (indentation, syntax, style, simplicity, readability)
- [ ] Wonder if you can improve the existing code
