### PR TITLE
chore: add comment to undestand why the order is important in SchemaSerializer

### DIFF
--- a/src/serializers/schema.js
+++ b/src/serializers/schema.js
@@ -7,6 +7,7 @@ const { apimapSorter } = context.inject();
 // NOTICE: If a modification is made here, don't forget to replicate it in the toolbelt.
 function SchemaSerializer() {
   // WARNING: Attributes declaration order is important for .forestadmin-schema.json format.
+  //          It must be ordered by "importance" to ease the JSON reading for users.
   const options = {
     id: 'name',
     // TODO: Remove nameOld attribute once the lianas versions older than 2.0.0 are minority.


### PR DESCRIPTION
Adding a comment to help us understand the purpose of "order" in `SchemaSerializer`

See:

> https://github.com/ForestAdmin/forest-express/blob/master/src/serializers/schema.js#L9
WARNING: Attributes declaration order is important for .forestadmin-schema.json format.
On sait pourquoi et quel ordre il faut donner ? (pour pas que je fasse de bêtises)

> Arnaud:f-forest:  8 minutes ago
par ordre d’importance des propriétés pour rendre la lecture des objets facile dans le JSON

> Arnaud:f-forest:  6 minutes ago
(en tout cas les clés qui définissent des caractéristiques proches sont côte à côte)

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
