### PR TITLE
refactor: add string utils in init

### DIFF
--- a/src/context/init.js
+++ b/src/context/init.js
@@ -25,6 +25,7 @@ const stringUtils = require('../utils/string');
  *  forestServerRequester: import('../services/forest-server-requester');
  *  authorizationFinder: import('../services/authorization-finder');
  *  schemaFileUpdater: import('../services/schema-file-updater');
+ *  stringUtils: import('../utils/string');
  * }} Services
  *
  * @typedef {Utils & Services} Context

--- a/src/context/init.js
+++ b/src/context/init.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const ApplicationContext = require('./application-context');
 const errorMessages = require('../utils/error-messages');
+const stringUtils = require('../utils/string');
 const logger = require('../services/logger');
 const pathService = require('../services/path');
 const errorHandler = require('../services/exposed/error-handler');
@@ -10,11 +11,11 @@ const ApimapSorter = require('../services/apimap-sorter');
 const ApimapFieldsFormater = require('../services/apimap-fields-formater');
 const AuthorizationFinder = require('../services/authorization-finder');
 const SchemaFileUpdater = require('../services/schema-file-updater');
-const stringUtils = require('../utils/string');
 
 /**
  * @typedef {{
  *  errorMessages: import('../utils/error-messages');
+ *  stringUtils: import('../utils/string');
  * }} Utils
  *
  * @typedef {{
@@ -25,7 +26,6 @@ const stringUtils = require('../utils/string');
  *  forestServerRequester: import('../services/forest-server-requester');
  *  authorizationFinder: import('../services/authorization-finder');
  *  schemaFileUpdater: import('../services/schema-file-updater');
- *  stringUtils: import('../utils/string');
  * }} Services
  *
  * @typedef {Utils & Services} Context

--- a/src/context/init.js
+++ b/src/context/init.js
@@ -10,6 +10,7 @@ const ApimapSorter = require('../services/apimap-sorter');
 const ApimapFieldsFormater = require('../services/apimap-fields-formater');
 const AuthorizationFinder = require('../services/authorization-finder');
 const SchemaFileUpdater = require('../services/schema-file-updater');
+const stringUtils = require('../utils/string');
 
 /**
  * @typedef {{
@@ -46,6 +47,7 @@ function initServices(context) {
   context.addInstance('ipWhitelist', ipWhitelist);
   context.addInstance('forestServerRequester', forestServerRequester);
   context.addInstance('writeFileSync', (...args) => fs.writeFileSync(...args));
+  context.addInstance('stringUtils', stringUtils);
   context.addClass(ApimapFieldsFormater);
   context.addClass(AuthorizationFinder);
   context.addClass(ApimapSorter);

--- a/src/context/init.js
+++ b/src/context/init.js
@@ -36,6 +36,7 @@ const SchemaFileUpdater = require('../services/schema-file-updater');
  */
 function initUtils(context) {
   context.addInstance('errorMessages', errorMessages);
+  context.addInstance('stringUtils', stringUtils);
 }
 
 /**
@@ -48,7 +49,6 @@ function initServices(context) {
   context.addInstance('ipWhitelist', ipWhitelist);
   context.addInstance('forestServerRequester', forestServerRequester);
   context.addInstance('writeFileSync', (...args) => fs.writeFileSync(...args));
-  context.addInstance('stringUtils', stringUtils);
   context.addClass(ApimapFieldsFormater);
   context.addClass(AuthorizationFinder);
   context.addClass(ApimapSorter);


### PR DESCRIPTION
I need `string` utility as inject to refactor `src/routes/actions.js` to develop this feature: https://app.clickup.com/t/a6yc11. PR waiting for this: https://github.com/ForestAdmin/forest-express/pull/538

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
