### PR TITLE
refactor: add schemas generator in init

### DIFF
--- a/src/context/init.js
+++ b/src/context/init.js
@@ -10,6 +10,7 @@ const ApimapSorter = require('../services/apimap-sorter');
 const ApimapFieldsFormater = require('../services/apimap-fields-formater');
 const AuthorizationFinder = require('../services/authorization-finder');
 const SchemaFileUpdater = require('../services/schema-file-updater');
+const schemasGenerator = require('../generators/schemas');
 
 /**
  * @typedef {{
@@ -24,6 +25,7 @@ const SchemaFileUpdater = require('../services/schema-file-updater');
  *  forestServerRequester: import('../services/forest-server-requester');
  *  authorizationFinder: import('../services/authorization-finder');
  *  schemaFileUpdater: import('../services/schema-file-updater');
+ *  schemasGenerator: import('../generators/schemas');
  * }} Services
  *
  * @typedef {Utils & Services} Context
@@ -46,6 +48,7 @@ function initServices(context) {
   context.addInstance('ipWhitelist', ipWhitelist);
   context.addInstance('forestServerRequester', forestServerRequester);
   context.addInstance('writeFileSync', (...args) => fs.writeFileSync(...args));
+  context.addInstance('schemasGenerator', schemasGenerator);
   context.addClass(ApimapFieldsFormater);
   context.addClass(AuthorizationFinder);
   context.addClass(ApimapSorter);

--- a/src/generators/schemas.js
+++ b/src/generators/schemas.js
@@ -1,8 +1,7 @@
 const P = require('bluebird');
-const _ = require('lodash');
 
 function isArray(object) {
-  return object && _.isArray(object);
+  return object && Array.isArray(object);
 }
 
 module.exports = {
@@ -24,16 +23,14 @@ module.exports = {
             if (that.schemas[modelName]) {
               const currentSchema = that.schemas[modelName];
 
-              schema.fields = _.concat(schema.fields || [], currentSchema.fields || []);
-              schema.actions = _.concat(schema.actions || [], currentSchema.actions || []);
-              schema.segments = _.concat(schema.segments || [], currentSchema.segments || []);
+              schema.fields = (schema.fields || []).concat(currentSchema.fields || []);
+              schema.actions = (schema.actions || []).concat(currentSchema.actions || []);
+              schema.segments = (schema.segments || []).concat(currentSchema.segments || []);
 
               // NOTICE: Set this value only if searchFields property as been declared somewhere.
               if (isArray(schema.searchFields) || isArray(currentSchema.searchFields)) {
-                schema.searchFields = _.concat(
-                  schema.searchFields || [],
-                  currentSchema.searchFields || [],
-                );
+                schema.searchFields = (schema.searchFields || [])
+                  .concat(currentSchema.searchFields || []);
               }
             }
 

--- a/test/generators/schemas.test.js
+++ b/test/generators/schemas.test.js
@@ -1,0 +1,21 @@
+const schemasGenerator = require('../../src/generators/schemas');
+
+describe('generators > schemas', () => {
+  it('should build schemas', async () => {
+    expect.assertions(2);
+    const implementation = {
+      SchemaAdapter: async () => ({}),
+      getModelName: jest.fn(() => 'model name'),
+    };
+    const integrator = {
+      defineFields: jest.fn(),
+      defineSegments: jest.fn(),
+    };
+    const models = [{}, {}];
+    const opts = {};
+    await schemasGenerator.perform(implementation, integrator, models, opts);
+
+    expect(integrator.defineFields).toHaveBeenCalledTimes(models.length);
+    expect(integrator.defineSegments).toHaveBeenCalledTimes(models.length);
+  });
+});

--- a/test/generators/schemas.test.js
+++ b/test/generators/schemas.test.js
@@ -1,11 +1,14 @@
+const uuidV1 = require('uuid/v1');
 const schemasGenerator = require('../../src/generators/schemas');
+
 
 describe('generators > schemas', () => {
   it('should build schemas', async () => {
-    expect.assertions(2);
+    expect.assertions(3);
+
     const implementation = {
       SchemaAdapter: async () => ({}),
-      getModelName: jest.fn(() => 'model name'),
+      getModelName: jest.fn(() => 'myModel'),
     };
     const integrator = {
       defineFields: jest.fn(),
@@ -13,9 +16,81 @@ describe('generators > schemas', () => {
     };
     const models = [{}, {}];
     const opts = {};
+
+    schemasGenerator.schemas = {};
     await schemasGenerator.perform(implementation, integrator, models, opts);
 
     expect(integrator.defineFields).toHaveBeenCalledTimes(models.length);
     expect(integrator.defineSegments).toHaveBeenCalledTimes(models.length);
+    expect(schemasGenerator.schemas.myModel).toStrictEqual({
+      isSearchable: true, fields: [], actions: [], segments: [],
+    });
+  });
+
+  it('should merge fields, actions, segments and searchFields when same model is called twice', async () => {
+    expect.assertions(5);
+
+    const implementation = {
+      SchemaAdapter: async () => ({
+        fields: [uuidV1()],
+        segments: [uuidV1()],
+        actions: [uuidV1()],
+        searchFields: [uuidV1()],
+      }),
+      getModelName: jest.fn(() => 'myModel'),
+    };
+    const integrator = {
+      defineFields: jest.fn(),
+      defineSegments: jest.fn(),
+    };
+    const models = [{}, {}];
+    const opts = {};
+
+    schemasGenerator.schemas = {};
+    await schemasGenerator.perform(implementation, integrator, models, opts);
+
+    expect(Object.keys(schemasGenerator.schemas)).toHaveLength(1);
+    expect(schemasGenerator.schemas.myModel.fields).toHaveLength(2);
+    expect(schemasGenerator.schemas.myModel.segments).toHaveLength(2);
+    expect(schemasGenerator.schemas.myModel.actions).toHaveLength(2);
+    expect(schemasGenerator.schemas.myModel.searchFields).toHaveLength(2);
+  });
+
+  it('should not mix models', async () => {
+    expect.assertions(9);
+
+    const implementation = {
+      SchemaAdapter: async () => ({
+        fields: [uuidV1()],
+        segments: [uuidV1()],
+        actions: [uuidV1()],
+        searchFields: [uuidV1()],
+      }),
+      getModelName: jest.fn(() => uuidV1()),
+    };
+    const integrator = {
+      defineFields: jest.fn(),
+      defineSegments: jest.fn(),
+    };
+    const models = [{}, {}];
+    const opts = {};
+
+    schemasGenerator.schemas = {};
+    await schemasGenerator.perform(implementation, integrator, models, opts);
+
+    expect(Object.keys(schemasGenerator.schemas)).toHaveLength(2);
+
+    const [firstObjectKey, secondObjectKey] = Object.keys(schemasGenerator.schemas);
+    const firstObject = schemasGenerator.schemas[firstObjectKey];
+    const secondObject = schemasGenerator.schemas[secondObjectKey];
+
+    expect(firstObject.fields).toHaveLength(1);
+    expect(firstObject.segments).toHaveLength(1);
+    expect(firstObject.actions).toHaveLength(1);
+    expect(firstObject.searchFields).toHaveLength(1);
+    expect(secondObject.fields).toHaveLength(1);
+    expect(secondObject.segments).toHaveLength(1);
+    expect(secondObject.actions).toHaveLength(1);
+    expect(secondObject.searchFields).toHaveLength(1);
   });
 });


### PR DESCRIPTION
I need `schemas` generator as inject to refactor `src/routes/actions.js` to develop this feature: https://app.clickup.com/t/a6yc11. PR waiting for this: https://github.com/ForestAdmin/forest-express/pull/538

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
