### PR TITLE
ci: add skip_cleanup back to avoid build fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ jobs:
       script: skip
       deploy:
         provider: script
+        skip_cleanup: true
         on:
           branch: master
         script: yarn && yarn build && npx semantic-release


### PR DESCRIPTION
Build fails due to log size: https://travis-ci.com/github/ForestAdmin/forest-express/jobs/443393577

Since we are not using [dpl v2](https://docs.travis-ci.com/user/deployment-v2) we have to get `skip_cleanup: true` back even if it triggers a warning (source: https://github.com/ForestAdmin/forest-express/pull/381). Sources: 

 - Documentation about `skip_cleanup: true` in dpl v2: https://docs.travis-ci.com/user/deployment-v2#cleaning-up-the-git-working-directory
 - Issue I opened in Travis community forum: https://travis-ci.community/t/large-number-of-node-modules-js-already-exists-no-checkout-log-messages/10627/3?u=rap2h
 - Semantic release: https://github.com/semantic-release/semantic-release/blob/master/docs/recipes/travis.md#nodejs-projects-configuration

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [ ] Wonder if you can improve the existing code
