### PR TITLE
fix(smart-action): widgetEdit should not be erased when change hook is triggered

### DIFF
--- a/src/utils/widgets.js
+++ b/src/utils/widgets.js
@@ -52,17 +52,16 @@ const V1ToV2EditWidgetsMapping = {
  * @param {*} field A smart action field
  */
 function setFieldWidget(field) {
-  field.widgetEdit = null;
-
-  if (field.widget && !field.widgetEdit) {
+  if (field.widget) {
     if (V1ToV2EditWidgetsMapping[field.widget]) {
       field.widgetEdit = { name: V1ToV2EditWidgetsMapping[field.widget], parameters: { } };
     } else if (widgetEditList.includes(field.widget)) {
       field.widgetEdit = { name: field.widget, parameters: { } };
+    } else {
+      field.widgetEdit = null;
     }
+    delete field.widget;
   }
-
-  delete field.widget;
 }
 
 module.exports = {

--- a/test/utils/widgets.test.js
+++ b/test/utils/widgets.test.js
@@ -2,14 +2,6 @@ const { setFieldWidget } = require('../../src/utils/widgets');
 
 describe('utils › widgets', () => {
   describe('setFieldWidget', () => {
-    it('should add widgetEdit to null when there is no widget property', () => {
-      expect.assertions(1);
-      const field = {};
-      const expected = { widgetEdit: null };
-      setFieldWidget(field);
-      expect(field).toStrictEqual(expected);
-    });
-
     it('should remove widget property', () => {
       expect.assertions(1);
       const field = { widget: 'hop' };


### PR DESCRIPTION
## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
