### PR TITLE
fix: allow to authenticate with Safari

### DIFF
--- a/src/routes/authentication.js
+++ b/src/routes/authentication.js
@@ -88,7 +88,7 @@ async function startAuthentication(context, request, response, next) {
       { renderingId },
     );
 
-    response.redirect(result.authorizationUrl);
+    response.status(200).send(result);
   } catch (e) {
     handleError(context, e, response, next);
   }

--- a/test/routes/authentication.test.js
+++ b/test/routes/authentication.test.js
@@ -79,8 +79,8 @@ describe('routes > authentication', () => {
             });
         });
 
-        expect(receivedResponse.status).toBe(302);
-        expect(receivedResponse.headers.location).toStrictEqual('https://authorization');
+        expect(receivedResponse.status).toBe(200);
+        expect(receivedResponse.body.authorizationUrl).toStrictEqual('https://authorization');
       } finally {
         sandbox.restore();
       }


### PR DESCRIPTION
There was an [issue](https://app.clickup.com/t/c0xx0v) with Safari which does not allow to set cookie between cross domain by default so there is a little change with the authentication flow. 

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code
