### PR TITLE
fix(forestadmin-schema): regenerate forestadmin schema only when files are valid

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,7 @@ function getModels() {
 
 function requireAllModels(modelsDir) {
   if (modelsDir) {
+    let lastFileLoadedPath;
     try {
       const isJavascriptOrTypescriptFileName = (fileName) =>
         fileName.endsWith('.js') || (fileName.endsWith('.ts') && !fileName.endsWith('.d.ts'));
@@ -75,10 +76,20 @@ function requireAllModels(modelsDir) {
         excludeDirs: /^__tests__$/,
         filter: (fileName) =>
           isJavascriptOrTypescriptFileName(fileName) && !isTestFileName(fileName),
+        map: (name, filePath) => {
+          lastFileLoadedPath = filePath;
+          return name;
+        },
         recursive: true,
       });
     } catch (error) {
-      logger.error('Cannot read a file for the following reason: ', error);
+      // Require all does not throw any error message.
+      // `lastFileLoadedPath` is used to locate where the issue was
+      // and to forward a comprehensive error message
+      const errorMessage = lastFileLoadedPath
+        ? `Cannot require the file "${lastFileLoadedPath}".`
+        : `An unexcepted error occured while requiring files in the "${modelsDir}" directory`;
+      throw new Error(errorMessage);
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -63,34 +63,19 @@ function getModels() {
 
 function requireAllModels(modelsDir) {
   if (modelsDir) {
-    let lastFileLoadedPath;
-    try {
-      const isJavascriptOrTypescriptFileName = (fileName) =>
-        fileName.endsWith('.js') || (fileName.endsWith('.ts') && !fileName.endsWith('.d.ts'));
+    const isJavascriptOrTypescriptFileName = (fileName) =>
+      fileName.endsWith('.js') || (fileName.endsWith('.ts') && !fileName.endsWith('.d.ts'));
 
-      // NOTICE: Ends with `.spec.js`, `.spec.ts`, `.test.js` or `.test.ts`.
-      const isTestFileName = (fileName) => fileName.match(/(?:\.test|\.spec)\.(?:js||ts)$/g);
+    // NOTICE: Ends with `.spec.js`, `.spec.ts`, `.test.js` or `.test.ts`.
+    const isTestFileName = (fileName) => fileName.match(/(?:\.test|\.spec)\.(?:js||ts)$/g);
 
-      requireAll({
-        dirname: modelsDir,
-        excludeDirs: /^__tests__$/,
-        filter: (fileName) =>
-          isJavascriptOrTypescriptFileName(fileName) && !isTestFileName(fileName),
-        map: (name, filePath) => {
-          lastFileLoadedPath = filePath;
-          return name;
-        },
-        recursive: true,
-      });
-    } catch (error) {
-      // Require all does not throw any error message.
-      // `lastFileLoadedPath` is used to locate where the issue was
-      // and to forward a comprehensive error message
-      const errorMessage = lastFileLoadedPath
-        ? `Cannot require the file "${lastFileLoadedPath}".`
-        : `An unexcepted error occured while requiring files in the "${modelsDir}" directory.`;
-      throw new Error(errorMessage);
-    }
+    requireAll({
+      dirname: modelsDir,
+      excludeDirs: /^__tests__$/,
+      filter: (fileName) =>
+        isJavascriptOrTypescriptFileName(fileName) && !isTestFileName(fileName),
+      recursive: true,
+    });
   }
 
   // NOTICE: User didn't provide a modelsDir but may already have required them manually so they

--- a/src/index.js
+++ b/src/index.js
@@ -88,7 +88,7 @@ function requireAllModels(modelsDir) {
       // and to forward a comprehensive error message
       const errorMessage = lastFileLoadedPath
         ? `Cannot require the file "${lastFileLoadedPath}".`
-        : `An unexcepted error occured while requiring files in the "${modelsDir}" directory`;
+        : `An unexcepted error occured while requiring files in the "${modelsDir}" directory.`;
       throw new Error(errorMessage);
     }
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,6 @@
 const request = require('supertest');
 const express = require('express');
+const path = require('path');
 
 function resetRequireIndex(mockExtraModules) {
   jest.resetModules();
@@ -50,24 +51,28 @@ describe('liana > index', () => {
     });
 
     describe('when requiring all files of the configDir', () => {
-      describe('when requiring all throws an error', () => {
+      describe('when requireAll() throws an error', () => {
         it('should return a rejected promise', async () => {
           expect.assertions(1);
+
           const requireAllMockModule = () => {
             jest.mock('require-all');
-            // eslint-disable-next-line global-require
+            /* eslint-disable global-require */
             const requireAll = require('require-all');
-            // eslint-disable-next-line global-require
             const fs = require('fs');
+            /* eslint-enable global-require */
             jest.spyOn(fs, 'existsSync').mockReturnValue(true);
             requireAll.mockImplementation(() => { throw new Error(); });
           };
 
           const forestExpress = resetRequireIndex(requireAllMockModule);
           const configDir = './something';
+          const configDirAbsolutePath = path.resolve('.', configDir);
           const implementation = createFakeImplementation({ configDir });
 
-          await expect(() => forestExpress.init(implementation)).rejects.toThrow(expect.anything());
+          await expect(() => forestExpress.init(implementation))
+            .rejects
+            .toThrow(`An unexcepted error occured while requiring files in the "${configDirAbsolutePath}" directory`);
         });
       });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,5 @@
 const request = require('supertest');
 const express = require('express');
-const path = require('path');
 
 function resetRequireIndex(mockExtraModules) {
   jest.resetModules();
@@ -55,6 +54,7 @@ describe('liana > index', () => {
         it('should return a rejected promise', async () => {
           expect.assertions(1);
 
+          const expectedErrorMessage = 'This is the expected error';
           const requireAllMockModule = () => {
             jest.mock('require-all');
             /* eslint-disable global-require */
@@ -62,17 +62,16 @@ describe('liana > index', () => {
             const fs = require('fs');
             /* eslint-enable global-require */
             jest.spyOn(fs, 'existsSync').mockReturnValue(true);
-            requireAll.mockImplementation(() => { throw new Error(); });
+            requireAll.mockImplementation(() => { throw new Error(expectedErrorMessage); });
           };
 
           const forestExpress = resetRequireIndex(requireAllMockModule);
           const configDir = './something';
-          const configDirAbsolutePath = path.resolve('.', configDir);
           const implementation = createFakeImplementation({ configDir });
 
           await expect(() => forestExpress.init(implementation))
             .rejects
-            .toThrow(`An unexcepted error occured while requiring files in the "${configDirAbsolutePath}" directory.`);
+            .toThrow(expectedErrorMessage);
         });
       });
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -49,6 +49,29 @@ describe('liana > index', () => {
       });
     });
 
+    describe('when requiring all files of the configDir', () => {
+      describe('when requiring all throws an error', () => {
+        it('should return a rejected promise', async () => {
+          expect.assertions(1);
+          const requireAllMockModule = () => {
+            jest.mock('require-all');
+            // eslint-disable-next-line global-require
+            const requireAll = require('require-all');
+            // eslint-disable-next-line global-require
+            const fs = require('fs');
+            jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+            requireAll.mockImplementation(() => { throw new Error(); });
+          };
+
+          const forestExpress = resetRequireIndex(requireAllMockModule);
+          const configDir = './something';
+          const implementation = createFakeImplementation({ configDir });
+
+          await expect(() => forestExpress.init(implementation)).rejects.toThrow(expect.anything());
+        });
+      });
+    });
+
     describe('with a valid configuration', () => {
       it('should return a promise', async () => {
         expect.assertions(1);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -72,7 +72,7 @@ describe('liana > index', () => {
 
           await expect(() => forestExpress.init(implementation))
             .rejects
-            .toThrow(`An unexcepted error occured while requiring files in the "${configDirAbsolutePath}" directory`);
+            .toThrow(`An unexcepted error occured while requiring files in the "${configDirAbsolutePath}" directory.`);
         });
       });
     });


### PR DESCRIPTION
## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code

CC complains about diff-coverage being not sufficient, but I don't think I'll be able to test the `map: xxx` code without reworking the `index.js` file. Using the real `require-all` module instead of a mock implies that I need to have a whole directory with files, which should contains syntax error in order to test the behavior I added.

If you find have any good idea on how I can test this function without loads of fixtures...

