### PR TITLE
fix: fix record creation with unconventional pk field acting as a fk

### DIFF
--- a/src/serializers/schema.js
+++ b/src/serializers/schema.js
@@ -43,6 +43,7 @@ function SchemaSerializer() {
         'relationship',
         'widget',
         'validations',
+        'fkIsPk',
       ],
     },
     validations: {

--- a/src/serializers/schema.js
+++ b/src/serializers/schema.js
@@ -43,7 +43,7 @@ function SchemaSerializer() {
         'relationship',
         'widget',
         'validations',
-        'fkIsPk',
+        'foreignAndPrimaryKey',
       ],
     },
     validations: {


### PR DESCRIPTION
### This Pr works with:
- [forest-express-sequelize](https://github.com/ForestAdmin/forest-express-sequelize/pull/598)
- [forest-admin](https://github.com/ForestAdmin/forestadmin/pull/2898)
- [forest-admin-server](https://github.com/ForestAdmin/forestadmin-server/pull/2009)

### How to test?
Please follow in the right order theses steps, as there is still an issue with the forestadmin-server update

1. Switch to the `fix-primary-foreign-key-to-primary-key` on every projects
2. Launch forestadmin-server and forestadmin
3. In the forest-express project, run `yarn build:watch`
4. In the forest-express-sequelize, run `yarn link forest-express`, then `yarn build:watch`
5. Create a postgresql database with this dump:
```
create table if not exists customer
(
	id serial not null
		constraint customer_pk
			primary key,
	name varchar not null
);

create unique index if not exists customer_id_uindex
	on customer (id);

create table if not exists picture
(
	name varchar not null,
	customer_id integer not null
		constraint picture_pk
			primary key
		constraint picture_customer_id_fk
			references customer
);

```
```diff
- BE CAREFUL HERE
```
6. Create a project thanks to the onboarding frontend, BUT DO NOT LAUNCH IT
7. link your project to `forest-express-sequelize` with `yarn link forest-express-sequelize`
8. Launch your project

## Pull Request checklist:

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Test manually the implemented changes
- [ ] Review my own code (indentation, syntax, style, simplicity, readability)
- [ ] Wonder if you can improve the existing code
