### PR TITLE
feat(authentication): return a specific error during authorization if received an error about 2FA

### DIFF
--- a/src/services/authorization-finder.js
+++ b/src/services/authorization-finder.js
@@ -30,9 +30,8 @@ class AuthorizationFinder {
     switch (error.message) {
       case this.errorMessages.SERVER_TRANSACTION.SECRET_AND_RENDERINGID_INCONSISTENT:
         return new InconsistentSecretAndRenderingError();
-      case this.errorMessages.SERVER_TRANSACTION.SECRET_NOT_FOUND: {
+      case this.errorMessages.SERVER_TRANSACTION.SECRET_NOT_FOUND:
         return new SecretNotFoundError();
-      }
       default:
     }
 

--- a/src/services/authorization-finder.js
+++ b/src/services/authorization-finder.js
@@ -1,3 +1,7 @@
+const InconsistentSecretAndRenderingError = require('../utils/errors/authentication/inconsistent-secret-rendering-error');
+const SecretNotFoundError = require('../utils/errors/authentication/secret-not-found-error');
+const TwoFactorAuthenticationRequiredError = require('../utils/errors/authentication/two-factor-authentication-required-error');
+
 class AuthorizationFinder {
   /** @private @readonly @type {import('./forest-server-requester')} */
   forestServerRequester;
@@ -22,20 +26,28 @@ class AuthorizationFinder {
    * @param {Error} error
    * @returns {string}
    */
-  _generateAuthenticationErrorMessage(error) {
-    let errorMessageToForward;
+  _generateAuthenticationError(error) {
     switch (error.message) {
       case this.errorMessages.SERVER_TRANSACTION.SECRET_AND_RENDERINGID_INCONSISTENT:
-        errorMessageToForward = error.message;
-        break;
-      case this.errorMessages.SERVER_TRANSACTION.SECRET_NOT_FOUND:
-        errorMessageToForward = 'Cannot retrieve the project you\'re trying to unlock. '
-            + 'Please check that you\'re using the right environment secret regarding your project and environment.';
-        break;
-      default: errorMessageToForward = undefined;
+        return new InconsistentSecretAndRenderingError();
+      case this.errorMessages.SERVER_TRANSACTION.SECRET_NOT_FOUND: {
+        return new SecretNotFoundError();
+      }
+      default:
     }
 
-    return errorMessageToForward;
+    // eslint-disable-next-line camelcase
+    const serverErrors = error?.jse_cause?.response?.body?.errors;
+    const serverError = serverErrors && serverErrors[0];
+
+    if (serverError?.name === this.errorMessages
+      .SERVER_TRANSACTION
+      .names
+      .TWO_FACTOR_AUTHENTICATION_REQUIRED) {
+      return new TwoFactorAuthenticationRequiredError();
+    }
+
+    return new Error();
   }
 
   /**
@@ -76,8 +88,9 @@ class AuthorizationFinder {
       user.id = result.data.id;
       return user;
     } catch (error) {
-      this.logger.error('Authorization error: ', error);
-      throw new Error(this._generateAuthenticationErrorMessage(error));
+      // eslint-disable-next-line camelcase
+      this.logger.error('Authorization error: ', error?.jse_cause?.response.body || error);
+      throw this._generateAuthenticationError(error);
     }
   }
 }

--- a/src/services/exposed/error-handler.js
+++ b/src/services/exposed/error-handler.js
@@ -18,6 +18,10 @@ function errorHandler({ logger } = {}) {
         error.message = error.errors[0].message;
       }
 
+      if (error && error.errors && error.errors[0] && error.errors[0].name) {
+        error.name = error.errors[0].name;
+      }
+
       if (!error.status && logger) {
         // NOTICE: Unexpected errors should log an error in the console.
         logger.error('Unexpected error: ', error);
@@ -27,6 +31,7 @@ function errorHandler({ logger } = {}) {
         errors: [{
           status: error.status || 500,
           detail: error.message,
+          name: error.name,
         }],
       });
     } else {

--- a/src/utils/error-messages.js
+++ b/src/utils/error-messages.js
@@ -12,4 +12,7 @@ exports.SERVER_TRANSACTION = {
   INVALID_STATE_RENDERING_ID: 'Invalid response from the authentication server: the state does not contain a renderingId',
   MISSING_RENDERING_ID: 'Authentication request must contain a renderingId',
   INVALID_RENDERING_ID: 'The parameter renderingId is not valid',
+  names: {
+    TWO_FACTOR_AUTHENTICATION_REQUIRED: 'TwoFactorAuthenticationRequiredForbiddenError',
+  },
 };

--- a/src/utils/errors/authentication/inconsistent-secret-rendering-error.js
+++ b/src/utils/errors/authentication/inconsistent-secret-rendering-error.js
@@ -1,0 +1,11 @@
+const errorMessages = require('../../error-messages');
+
+class InconsistentSecretAndRenderingError extends Error {
+  constructor() {
+    super(errorMessages.SERVER_TRANSACTION.SECRET_AND_RENDERINGID_INCONSISTENT);
+    this.name = this.constructor.name;
+    this.status = 500;
+  }
+}
+
+module.exports = InconsistentSecretAndRenderingError;

--- a/src/utils/errors/authentication/secret-not-found-error.js
+++ b/src/utils/errors/authentication/secret-not-found-error.js
@@ -1,0 +1,10 @@
+class SecretNotFoundError extends Error {
+  constructor() {
+    super('Cannot retrieve the project you\'re trying to unlock. '
+    + 'Please check that you\'re using the right environment secret regarding your project and environment.');
+    this.name = this.constructor.name;
+    this.status = 500;
+  }
+}
+
+module.exports = SecretNotFoundError;

--- a/src/utils/errors/authentication/two-factor-authentication-required-error.js
+++ b/src/utils/errors/authentication/two-factor-authentication-required-error.js
@@ -1,0 +1,9 @@
+class TwoFactorAuthenticationRequiredError extends Error {
+  constructor() {
+    super('Two factor authentication required');
+    this.name = this.constructor.name;
+    this.status = 403;
+  }
+}
+
+module.exports = TwoFactorAuthenticationRequiredError;

--- a/test/services/authorization-finder.test.js
+++ b/test/services/authorization-finder.test.js
@@ -1,4 +1,7 @@
 const AuthorizationFinder = require('../../src/services/authorization-finder');
+const InconsistentSecretAndRenderingError = require('../../src/utils/errors/authentication/inconsistent-secret-rendering-error');
+const SecretNotFoundError = require('../../src/utils/errors/authentication/secret-not-found-error');
+const TwoFactorAuthenticationRequiredError = require('../../src/utils/errors/authentication/two-factor-authentication-required-error');
 
 describe('authorization-finder', () => {
   function setup() {
@@ -16,6 +19,9 @@ describe('authorization-finder', () => {
       SERVER_TRANSACTION: {
         SECRET_AND_RENDERINGID_INCONSISTENT: 'inconsistent rendering id',
         SECRET_NOT_FOUND: 'secret not found',
+        names: {
+          TWO_FACTOR_AUTHENTICATION_REQUIRED: 'TwoFactorAuthenticationRequiredForbiddenError',
+        },
       },
     };
 
@@ -109,6 +115,88 @@ describe('authorization-finder', () => {
             null,
             { 'forest-token': 'THE-TOKEN' },
           );
+      });
+    });
+
+    describe('when the server returns an error', () => {
+      it('should return a InconsistentSecretAndRenderingError if the server returned this error', async () => {
+        expect.assertions(1);
+        const { authorizationFinder, forestServerRequester } = setup();
+
+        forestServerRequester.perform.mockRejectedValue({
+          message: 'inconsistent rendering id',
+        });
+
+        await expect(authorizationFinder.authenticate(
+          42,
+          'ABCDE',
+          false,
+          'alice@forestadmin.com',
+          'secret',
+          null,
+        )).rejects.toBeInstanceOf(InconsistentSecretAndRenderingError);
+      });
+
+      it('should return a SecretNotFoundError if the server returned this error', async () => {
+        expect.assertions(1);
+        const { authorizationFinder, forestServerRequester } = setup();
+
+        forestServerRequester.perform.mockRejectedValue({
+          message: 'secret not found',
+        });
+
+        await expect(authorizationFinder.authenticate(
+          42,
+          'ABCDE',
+          false,
+          'alice@forestadmin.com',
+          'secret',
+          null,
+        )).rejects.toBeInstanceOf(SecretNotFoundError);
+      });
+
+      it('should return a TwoFactorAuthenticationRequiredError if the server returned this kind of error', async () => {
+        expect.assertions(1);
+        const { authorizationFinder, forestServerRequester } = setup();
+
+        forestServerRequester.perform.mockRejectedValue({
+          jse_cause: {
+            response: {
+              body: {
+                errors: [{
+                  name: 'TwoFactorAuthenticationRequiredForbiddenError',
+                }],
+              },
+            },
+          },
+        });
+
+        await expect(authorizationFinder.authenticate(
+          42,
+          'ABCDE',
+          false,
+          'alice@forestadmin.com',
+          'secret',
+          null,
+        )).rejects.toBeInstanceOf(TwoFactorAuthenticationRequiredError);
+      });
+
+      it('should return an empty error if the server returned an unknown error', async () => {
+        expect.assertions(1);
+        const { authorizationFinder, forestServerRequester } = setup();
+
+        forestServerRequester.perform.mockRejectedValue({
+          message: 'unknown',
+        });
+
+        await expect(authorizationFinder.authenticate(
+          42,
+          'ABCDE',
+          false,
+          'alice@forestadmin.com',
+          'secret',
+          null,
+        )).rejects.toBeInstanceOf(Error);
       });
     });
   });


### PR DESCRIPTION
This modification is needed to identify why the authorization failed, and display the correct error message in the frontend.

In this case, instead of a 500 with an error message, we get a 403 and the error's name correctly encoded in the response, just as the server sends errors.

Linked to CU-ccukn4

## Pull Request checklist:

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Test manually the implemented changes
- [ ] Review my own code (indentation, syntax, style, simplicity, readability)
- [ ] Wonder if you can improve the existing code
