### PR TITLE
fix: include `/forest` route in CORS and authentication config

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -191,7 +191,7 @@ exports.init = async (Implementation) => {
     return Promise.resolve(app);
   }
 
-  const pathMounted = pathService.generate('*', configStore.lianaOptions);
+  const pathMounted = pathService.generateForInit('*', configStore.lianaOptions);
 
   auth.initAuth(configStore.lianaOptions);
 

--- a/src/services/path.js
+++ b/src/services/path.js
@@ -3,6 +3,13 @@ exports.generate = (path, options) => {
   return pathPrefix + path;
 };
 
+exports.generateForInit = (path, options) => {
+  if (options.expressParentApp) return '/';
+
+  const pathPrefix = '/forest';
+  return [`${pathPrefix}`, `${pathPrefix}/${path}`];
+};
+
 exports.generateForSmartActionCustomEndpoint = (path, options) => {
   if (options.expressParentApp) {
     return path.replace(/^\/?forest\//, '/');

--- a/src/services/path.js
+++ b/src/services/path.js
@@ -4,7 +4,7 @@ exports.generate = (path, options) => {
 };
 
 exports.generateForInit = (path, options) => {
-  if (options.expressParentApp) return '/';
+  if (options.expressParentApp) return `/${path}`;
 
   const pathPrefix = '/forest';
   return [`${pathPrefix}`, `${pathPrefix}/${path}`];

--- a/test/services/path.unit.test.js
+++ b/test/services/path.unit.test.js
@@ -1,0 +1,47 @@
+const path = require('../../src/services/path');
+
+describe('services > path', () => {
+  describe('generate', () => {
+    it('should preprend /forest', async () => {
+      expect.assertions(1);
+
+      const arg = 'dummy_path_value';
+      const options = {};
+      const generatedPath = path.generate(arg, options);
+
+      expect(generatedPath).toStrictEqual(`/forest/${arg}`);
+    });
+
+    it('should not prepend /forest with expressParentApp option', async () => {
+      expect.assertions(1);
+
+      const arg = 'dummy_path_value';
+      const options = { expressParentApp: true };
+      const generatedPath = path.generate(arg, options);
+
+      expect(generatedPath).toStrictEqual(`/${arg}`);
+    });
+  });
+
+  describe('generateForInit', () => {
+    it('should allow /forest and subpaths', async () => {
+      expect.assertions(1);
+
+      const arg = 'dummy_path_value';
+      const options = {};
+      const generatedPath = path.generateForInit(arg, options);
+
+      expect(generatedPath).toStrictEqual(['/forest', `/forest/${arg}`]);
+    });
+
+    it('should not include /forest with expressParentApp option', async () => {
+      expect.assertions(1);
+
+      const arg = 'dummy_path_value';
+      const options = { expressParentApp: true };
+      const generatedPath = path.generateForInit(arg, options);
+
+      expect(generatedPath).toStrictEqual(`/${arg}`);
+    });
+  });
+});


### PR DESCRIPTION
Linked to: CU-fuz99h.

## Pull Request checklist:

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [x] Test manually the implemented changes
- [x] Review my own code (indentation, syntax, style, simplicity, readability)
- [x] Wonder if you can improve the existing code



Before
* with parentApp: /*
* without parentApp: /forest/*

After
* with parentApp: /*
* without parentApp: [/forest, /forest/*]