### PR TITLE
feat(scopes): add scope retrieval service

### DIFF
--- a/src/context/init.js
+++ b/src/context/init.js
@@ -27,6 +27,7 @@ const ConfigStore = require('../services/config-store');
 const PermissionsChecker = require('../services/permissions-checker');
 const PermissionsGetter = require('../services/permissions-getter');
 const SchemaFileUpdater = require('../services/schema-file-updater');
+const ScopeService = require('../services/scope-service');
 const SmartActionHook = require('../services/smart-action-hook');
 const schemasGenerator = require('../generators/schemas');
 const ModelsManager = require('../services/models-manager');
@@ -74,6 +75,7 @@ function initValue(context) {
  *  forestServerRequester: import('../services/forest-server-requester');
  *  authorizationFinder: import('../services/authorization-finder');
  *  schemaFileUpdater: import('../services/schema-file-updater');
+ *  scopeService: import('../services/scope-service');
  *  apimapSender: import('../services/apimap-sender');
  *  permissionsChecker: import('../services/permissions-checker');
  *  permissionsGetter: import('../services/permissions-getter');
@@ -140,6 +142,7 @@ function initServices(context) {
   context.addClass(ApimapSorter);
   context.addClass(ApimapSender);
   context.addClass(SchemaFileUpdater);
+  context.addClass(ScopeService);
   context.addClass(ModelsManager);
   context.addClass(TokenService);
   context.addClass(OidcConfigurationRetrieverService);

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ const {
   modelsManager,
   fs,
   tokenService,
+  scopeService,
 } = context.inject();
 
 const PUBLIC_ROUTES = [
@@ -87,6 +88,7 @@ async function buildSchema() {
 
 exports.Schemas = Schemas;
 exports.logger = logger;
+exports.scopeService = scopeService;
 exports.ResourcesRoute = {};
 
 /**

--- a/src/services/scope-service.js
+++ b/src/services/scope-service.js
@@ -15,31 +15,7 @@ class ScopeService {
   async getScopes(renderingId) {
     const queryParams = { renderingId };
 
-    const scopes = await this.forestServerRequester.perform('/liana/scopes', this.environmentSecret, queryParams);
-    console.log('scopes', scopes);
-    return scopes;
-    // return this.forestServerRequester
-    //   .perform('/liana/scopes', this.environmentSecret, queryParams)
-    //   .then((responseBody) => {
-    //     this.isRolesACLActivated = responseBody.meta
-    //       ? responseBody.meta.rolesACLActivated
-    //       : false;
-
-    //     if (!responseBody.data) return null;
-
-    //     // NOTICE: Addtional permissions - live queries, stats parameters
-    //     this._setStatsPermissions(responseBody.stats, { environmentId });
-
-    //     if (renderingOnly) {
-    //       return responseBody.data.renderings
-    //         ? this._setRenderingPermissions(
-    //           renderingId, responseBody.data.renderings[renderingId], { environmentId },
-    //         )
-    //         : null;
-    //     }
-    //     return this._setPermissions(renderingId, responseBody.data, { environmentId });
-    //   })
-    //   .catch((error) => Promise.reject(new this.VError(error, 'Permissions error')));
+    return this.forestServerRequester.perform('/liana/scopes', this.environmentSecret, queryParams);
   }
 }
 

--- a/src/services/scope-service.js
+++ b/src/services/scope-service.js
@@ -1,0 +1,46 @@
+const context = require('../context');
+
+class ScopeService {
+  constructor({ permissionsGetter, configStore, forestServerRequester } = context.inject()) {
+    this.permissionsGetter = permissionsGetter;
+    this.configStore = configStore;
+    this.forestServerRequester = forestServerRequester;
+    this.scopes = {};
+  }
+
+  get environmentSecret() {
+    return this.configStore.lianaOptions.envSecret;
+  }
+
+  async getScopes(renderingId) {
+    const queryParams = { renderingId };
+
+    const scopes = await this.forestServerRequester.perform('/liana/scopes', this.environmentSecret, queryParams);
+    console.log('scopes', scopes);
+    return scopes;
+    // return this.forestServerRequester
+    //   .perform('/liana/scopes', this.environmentSecret, queryParams)
+    //   .then((responseBody) => {
+    //     this.isRolesACLActivated = responseBody.meta
+    //       ? responseBody.meta.rolesACLActivated
+    //       : false;
+
+    //     if (!responseBody.data) return null;
+
+    //     // NOTICE: Addtional permissions - live queries, stats parameters
+    //     this._setStatsPermissions(responseBody.stats, { environmentId });
+
+    //     if (renderingOnly) {
+    //       return responseBody.data.renderings
+    //         ? this._setRenderingPermissions(
+    //           renderingId, responseBody.data.renderings[renderingId], { environmentId },
+    //         )
+    //         : null;
+    //     }
+    //     return this._setPermissions(renderingId, responseBody.data, { environmentId });
+    //   })
+    //   .catch((error) => Promise.reject(new this.VError(error, 'Permissions error')));
+  }
+}
+
+module.exports = ScopeService;


### PR DESCRIPTION
Requires this backend [PR](https://github.com/ForestAdmin/forestadmin-server/pull/2427) to expose the `liana/scopes` route

No cache and security for now, this is a POC

Import the `scopeService` in `forest-express-sequelize`:

```
import { scopeService } from 'forest-express';

scopeService.getScopes(renderingId);
```
## Pull Request checklist:

- [ ] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)
- [ ] Test manually the implemented changes
- [ ] Review my own code (indentation, syntax, style, simplicity, readability)
- [ ] Wonder if you can improve the existing code
