### PR TITLE
feat: support yarn 2 pnp install mode

### DIFF
--- a/src/utils/project-directory.js
+++ b/src/utils/project-directory.js
@@ -1,23 +1,38 @@
 const path = require('path');
 
+// NOTICE: order does matter as packages install via yarn 2 pnp mode also
+// include node_modules in path
+const ROOT_PACKAGES_PATHS = [
+  // yarn 2 pnp mode
+  path.join('.yarn', 'cache'),
+  path.join('.yarn', 'unplugged'),
+  // usual yarn / npm
+  'node_modules',
+];
+
+function ensureAbsolutePath(subPathsToProject) {
+  // NOTICE: on POSIX system, empty path created by previous split is skipped by path.join.
+  if (!path.isAbsolute(path.join(...subPathsToProject))) {
+    return path.join(path.sep, ...subPathsToProject);
+  }
+  return path.join(...subPathsToProject);
+}
+
 class ProjectDirectoryUtils {
   constructor() {
     this.dirname = __dirname;
   }
 
   getAbsolutePath() {
-    // NOTICE: forest-express has not been sym linked.
-    if (this.dirname.includes('node_modules')) {
-      const splitPaths = this.dirname.split(path.sep);
-      const nodeModuleIndex = splitPaths.indexOf('node_modules');
-      const subPathsToProject = splitPaths.slice(0, nodeModuleIndex);
-
-      // NOTICE: on POSIX system, empty path created by previous split is skipped by path.join.
-      if (!path.isAbsolute(path.join(...subPathsToProject))) {
-        return path.join(path.sep, ...subPathsToProject);
+    for (let index = 0; index <= ROOT_PACKAGES_PATHS.length; index += 1) {
+      const rootPackagesPath = ROOT_PACKAGES_PATHS[index];
+      // NOTICE: forest-express has not been sym linked.
+      if (this.dirname.includes(rootPackagesPath)) {
+        const rootPathIndex = this.dirname.indexOf(rootPackagesPath);
+        const projectRootPath = this.dirname.substr(0, rootPathIndex);
+        const subPathsToProject = projectRootPath.split(path.sep);
+        return ensureAbsolutePath(subPathsToProject);
       }
-
-      return path.join(...subPathsToProject);
     }
 
     // NOTICE: forest-express is sym linked, assuming the process is running on project directory.

--- a/test/utils/project-directory.test.js
+++ b/test/utils/project-directory.test.js
@@ -19,6 +19,40 @@ describe('utils > project-directory', () => {
         cwdStub.restore();
         sinon.restore();
       });
+
+      describe('using forest-express install from yarn berry', () => {
+        it('should return the absolute path of the project directory', () => {
+          expect.assertions(1);
+
+          const cwdStub = sinon.stub(process, 'cwd');
+          cwdStub.returns('/User/user/projects');
+          sinon.replace(projectDirectoryUtils, 'dirname', '/Users/forestUser/projects/myLumberProject/.yarn/cache/forest-express-npm-8.3.1-a520e9a060-7158678646.zip/node_modules/forest-express/dist/utils');
+
+          const absoluteProjectPath = projectDirectoryUtils.getAbsolutePath();
+
+          expect(absoluteProjectPath).toStrictEqual('/Users/forestUser/projects/myLumberProject');
+
+          cwdStub.restore();
+          sinon.restore();
+        });
+
+        describe('in unplugged mode', () => {
+          it('should return the absolute path of the project directory', () => {
+            expect.assertions(1);
+
+            const cwdStub = sinon.stub(process, 'cwd');
+            cwdStub.returns('/User/user/projects');
+            sinon.replace(projectDirectoryUtils, 'dirname', '/Users/forestUser/projects/myLumberProject/.yarn/unplugged/forest-express-npm-8.3.1-a520e9a060-7158678646/dist/utils');
+
+            const absoluteProjectPath = projectDirectoryUtils.getAbsolutePath();
+
+            expect(absoluteProjectPath).toStrictEqual('/Users/forestUser/projects/myLumberProject');
+
+            cwdStub.restore();
+            sinon.restore();
+          });
+        });
+      });
     });
 
     describe('running the app in its directory', () => {
@@ -37,6 +71,40 @@ describe('utils > project-directory', () => {
 
         cwdStub.restore();
         sinon.restore();
+      });
+
+      describe('using forest-express install from yarn berry', () => {
+        it('should return the absolute path of the project directory', () => {
+          expect.assertions(1);
+
+          const cwdStub = sinon.stub(process, 'cwd');
+          cwdStub.returns('/User/user/projects/myLumberProject');
+          sinon.replace(projectDirectoryUtils, 'dirname', '/Users/forestUser/projects/myLumberProject/.yarn/cache/forest-express-npm-8.3.1-a520e9a060-7158678646.zip/node_modules/forest-express/dist/utils');
+
+          const absoluteProjectPath = projectDirectoryUtils.getAbsolutePath();
+
+          expect(absoluteProjectPath).toStrictEqual('/Users/forestUser/projects/myLumberProject');
+
+          cwdStub.restore();
+          sinon.restore();
+        });
+
+        describe('in unplugged mode', () => {
+          it('should return the absolute path of the project directory', () => {
+            expect.assertions(1);
+
+            const cwdStub = sinon.stub(process, 'cwd');
+            cwdStub.returns('/User/user/projects/myLumberProject');
+            sinon.replace(projectDirectoryUtils, 'dirname', '/Users/forestUser/projects/myLumberProject/.yarn/unplugged/forest-express-npm-8.3.1-a520e9a060-7158678646/dist/utils');
+
+            const absoluteProjectPath = projectDirectoryUtils.getAbsolutePath();
+
+            expect(absoluteProjectPath).toStrictEqual('/Users/forestUser/projects/myLumberProject');
+
+            cwdStub.restore();
+            sinon.restore();
+          });
+        });
       });
     });
 


### PR DESCRIPTION
Since [this commit](https://github.com/ForestAdmin/forest-express/commit/8fa5cda006d2b374fbe4ad3b933ae695164bf9b9), `forest-express` schema generation attempts to figure out the root of the user's project. Commit includes tests that give a good idea of the intent.

While it would be much preferable to be able to specify a path for this file to be generated in, it is not possible yet.

Problem is `ProjectDirectoryUtils.getAbsolutePath` code uses heuristics that aren't exactly right in all contexts.

When installed via [yarn 2 in pnp](https://yarnpkg.com/features/pnp) mode, the `__dirname` value has the shape of `/Users/forestUser/projects/myLumberProject/.yarn/cache/forest-express-npm-8.3.1-a520e9a060-7158678646.zip/node_modules/forest-express/dist/utils` and `ProjectDirectoryUtils.getAbsolutePath` returns something like `/Users/forestUser/projects/myLumberProject/.yarn/cache/forest-express-npm-8.3.1-a520e9a060-7158678646.zip` instead of `/Users/forestUser/projects/myLumberProject`. In turns, the schema update code tries to write in the `.zip`, which fails.

This fixes the heuristic so `ProjectDirectoryUtils.getAbsolutePath` properly returns the project root path in all cases.

Fixes #445 