### PR TITLE
chore: remove empty dict appended to log lines

### DIFF
--- a/src/services/logger.js
+++ b/src/services/logger.js
@@ -33,7 +33,7 @@ module.exports = winston.createLogger({
         winston.format.printf((info) => {
           let message = TITLE + info.message;
 
-          if (info.metadata) {
+          if (info.metadata && Object.keys(info.metadata).length) {
             message += `\n${JSON.stringify(info.metadata, null, 2)}`;
           }
 


### PR DESCRIPTION
To test, add a `logger.info` call anywhere in your `forest-express` code. There should be no more `{}` after the message.

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [x] Test manually the implemented changes
- [ ] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [ ] Consider the security impact of the changes made
