### PR TITLE
fix: allow nested models named attributes to be serialized

### DIFF
--- a/src/serializers/resource.js
+++ b/src/serializers/resource.js
@@ -23,7 +23,7 @@ function ResourceSerializer(
   const needsDateOnlyFormating = Implementation.getLianaName() === 'forest-express-sequelize'
     && semver.lt(Implementation.getOrmVersion(), '4.0.0');
 
-  const reservedWords = ['meta'];
+  const reservedWords = ['meta', 'attributes'];
   const fieldInfoDateonly = [];
   const fieldInfoPoint = [];
 


### PR DESCRIPTION
https://community.forestadmin.com/t/collections-unable-to-preview-collection-items-due-to-serialization-issues/5359/4

If there a nested model named "attributes" serialization fails. While the actual bug seems to be in JSONSerializer (it makes the assumption of: an object having the key "attributes" means it's a schema.), adding the words "attributes" to the reserved keywords on the forest side seems to fix this problem.

## Definition of Done

### General

- [X] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [X] Test manually the implemented changes
- [X] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [X ] Consider the security impact of the changes made
