### PR TITLE
feat(agent): add workflow executor proxy routes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ const StatRoutes = require('./routes/stats');
 const ForestRoutes = require('./routes/forest');
 const HealthCheckRoute = require('./routes/healthcheck');
 const initScopeRoutes = require('./routes/scopes');
+const initWorkflowExecutorRoutes = require('./routes/workflow-executor');
 const Schemas = require('./generators/schemas');
 const SchemaSerializer = require('./serializers/schema');
 const Integrator = require('./integrations');
@@ -307,6 +308,7 @@ exports.init = async (Implementation) => {
 
   new HealthCheckRoute(app, configStore.lianaOptions).perform();
   initScopeRoutes(app, inject());
+  initWorkflowExecutorRoutes(app, configStore.lianaOptions, inject());
   initAuthenticationRoutes(app, configStore.lianaOptions, inject());
 
   // Init

--- a/src/routes/workflow-executor.js
+++ b/src/routes/workflow-executor.js
@@ -1,0 +1,60 @@
+const superagent = require('superagent');
+
+const path = require('../services/path');
+const auth = require('../services/auth');
+
+const FORWARDED_REQUEST_HEADERS = ['authorization', 'cookie'];
+
+function pickForwardedHeaders(requestHeaders) {
+  const headers = {};
+  FORWARDED_REQUEST_HEADERS.forEach((name) => {
+    const value = requestHeaders[name];
+    if (value) {
+      headers[name] = value;
+    }
+  });
+  return headers;
+}
+
+function buildHandler({ baseUrl, suffix, logger }) {
+  const normalizedBase = baseUrl.replace(/\/+$/, '');
+
+  return async (request, response) => {
+    const url = `${normalizedBase}/runs/${request.params.runId}${suffix}`;
+    const method = request.method.toLowerCase();
+
+    try {
+      let outgoing = superagent[method](url).set(pickForwardedHeaders(request.headers));
+      if (request.query) outgoing = outgoing.query(request.query);
+      if (method !== 'get' && request.body !== undefined) {
+        outgoing = outgoing.send(request.body);
+      }
+      const upstream = await outgoing;
+      return response.status(upstream.status).json(upstream.body);
+    } catch (error) {
+      if (error.response) {
+        return response.status(error.response.status).json(error.response.body);
+      }
+      logger.error('[forest-express] workflow executor proxy error: ', error.message);
+      return response.status(503).json({ error: 'workflow_executor_unreachable' });
+    }
+  };
+}
+
+function initWorkflowExecutorRoutes(app, opts, { logger }) {
+  if (!opts.workflowExecutorUrl) return;
+
+  app.get(
+    path.generate('_internal/workflow-executions/:runId', opts),
+    auth.ensureAuthenticated,
+    buildHandler({ baseUrl: opts.workflowExecutorUrl, suffix: '', logger }),
+  );
+
+  app.post(
+    path.generate('_internal/workflow-executions/:runId/trigger', opts),
+    auth.ensureAuthenticated,
+    buildHandler({ baseUrl: opts.workflowExecutorUrl, suffix: '/trigger', logger }),
+  );
+}
+
+module.exports = initWorkflowExecutorRoutes;

--- a/src/routes/workflow-executor.js
+++ b/src/routes/workflow-executor.js
@@ -5,6 +5,11 @@ const auth = require('../services/auth');
 
 const FORWARDED_REQUEST_HEADERS = ['authorization', 'cookie'];
 
+// NOTICE: Bound the proxied request so a hanging executor cannot tie up the
+//         connection indefinitely. A timeout raises an error without `.response`,
+//         so it falls through to the 503 branch.
+const REQUEST_TIMEOUT = { response: 30000, deadline: 60000 };
+
 function pickForwardedHeaders(requestHeaders) {
   const headers = {};
   FORWARDED_REQUEST_HEADERS.forEach((name) => {
@@ -24,7 +29,9 @@ function buildHandler({ baseUrl, suffix, logger }) {
     const method = request.method.toLowerCase();
 
     try {
-      let outgoing = superagent[method](url).set(pickForwardedHeaders(request.headers));
+      let outgoing = superagent[method](url)
+        .timeout(REQUEST_TIMEOUT)
+        .set(pickForwardedHeaders(request.headers));
       if (request.query) outgoing = outgoing.query(request.query);
       if (method !== 'get' && request.body !== undefined) {
         outgoing = outgoing.send(request.body);

--- a/test/helpers/create-server.js
+++ b/test/helpers/create-server.js
@@ -9,7 +9,7 @@ const request = require('./request');
 
 let app;
 
-module.exports = async function createServer(envSecret, authSecret) {
+module.exports = async function createServer(envSecret, authSecret, extraOpts = {}) {
   if (app) {
     return app;
   }
@@ -30,6 +30,7 @@ module.exports = async function createServer(envSecret, authSecret) {
           models: {},
         },
       },
+      ...extraOpts,
     },
   };
 

--- a/test/routes/workflow-executor.test.js
+++ b/test/routes/workflow-executor.test.js
@@ -1,0 +1,173 @@
+const nock = require('nock');
+const request = require('supertest');
+
+const createServer = require('../helpers/create-server');
+const auth = require('../../src/services/auth');
+const initWorkflowExecutorRoutes = require('../../src/routes/workflow-executor');
+
+const envSecret = Array(65).join('0');
+const authSecret = Array(65).join('1');
+const executorBase = 'http://workflow-executor.test:4001';
+
+function mockEnsureAuthenticated() {
+  jest.spyOn(auth, 'ensureAuthenticated').mockImplementation((req, res, next) => next());
+}
+
+function teardown() {
+  jest.clearAllMocks();
+  nock.cleanAll();
+}
+
+describe('routes > workflow executor proxy', () => {
+  describe('get /forest/_internal/workflow-executions/:runId', () => {
+    it('forwards GET to executor /runs/:runId with query params', async () => {
+      mockEnsureAuthenticated();
+      const app = await createServer(envSecret, authSecret, { workflowExecutorUrl: executorBase });
+      const scope = nock(executorBase)
+        .get('/runs/run-123')
+        .query({ foo: 'bar' })
+        .reply(200, { id: 'run-123', state: 'pending' });
+
+      const response = await request(app)
+        .get('/forest/_internal/workflow-executions/run-123?foo=bar');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toStrictEqual({ id: 'run-123', state: 'pending' });
+      expect(scope.isDone()).toBe(true);
+      teardown();
+    });
+
+    it('forwards a 4xx executor response verbatim', async () => {
+      mockEnsureAuthenticated();
+      const app = await createServer(envSecret, authSecret, { workflowExecutorUrl: executorBase });
+      nock(executorBase).get('/runs/run-456').reply(422, { error: 'invalid_step' });
+
+      const response = await request(app)
+        .get('/forest/_internal/workflow-executions/run-456');
+
+      expect(response.status).toBe(422);
+      expect(response.body).toStrictEqual({ error: 'invalid_step' });
+      teardown();
+    });
+
+    it('returns 503 when the executor is unreachable', async () => {
+      mockEnsureAuthenticated();
+      const app = await createServer(envSecret, authSecret, { workflowExecutorUrl: executorBase });
+      nock(executorBase)
+        .get('/runs/run-789')
+        .replyWithError({ code: 'ECONNREFUSED', message: 'refused' });
+
+      const response = await request(app)
+        .get('/forest/_internal/workflow-executions/run-789');
+
+      expect(response.status).toBe(503);
+      expect(response.body).toStrictEqual({ error: 'workflow_executor_unreachable' });
+      teardown();
+    });
+  });
+
+  describe('post /forest/_internal/workflow-executions/:runId/trigger', () => {
+    it('forwards POST with the JSON body to executor /runs/:runId/trigger', async () => {
+      mockEnsureAuthenticated();
+      const app = await createServer(envSecret, authSecret, { workflowExecutorUrl: executorBase });
+      const scope = nock(executorBase)
+        .post('/runs/run-42/trigger', { step: 'approve', value: 42 })
+        .reply(200, { ok: true });
+
+      const response = await request(app)
+        .post('/forest/_internal/workflow-executions/run-42/trigger')
+        .send({ step: 'approve', value: 42 });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toStrictEqual({ ok: true });
+      expect(scope.isDone()).toBe(true);
+      teardown();
+    });
+  });
+
+  describe('header forwarding', () => {
+    // The test helper's express-jwt layer can't accept tokens signed with the
+    // agent's authSecret, so we exercise the handler directly: capture it via
+    // a fake express app and invoke it with a mock req/res.
+    function captureHandlers() {
+      const captured = {};
+      const fakeApp = {
+        get: jest.fn((_path, _auth, handler) => { captured.get = handler; }),
+        post: jest.fn((_path, _auth, handler) => { captured.post = handler; }),
+      };
+      initWorkflowExecutorRoutes(
+        fakeApp,
+        { workflowExecutorUrl: executorBase },
+        { logger: { error: jest.fn() } },
+      );
+      return captured;
+    }
+
+    function fakeRes() {
+      const res = {
+        status: jest.fn(),
+        json: jest.fn(),
+      };
+      res.status.mockReturnValue(res);
+      res.json.mockReturnValue(res);
+      return res;
+    }
+
+    it('forwards only Authorization and Cookie headers to the executor', async () => {
+      const { get } = captureHandlers();
+      const scope = nock(executorBase, {
+        reqheaders: {
+          authorization: 'Bearer abc',
+          cookie: 'forest_session_token=xyz',
+        },
+        badheaders: ['x-custom', 'forest-secret-key'],
+      })
+        .get('/runs/run-1')
+        .reply(200, { ok: true });
+
+      const req = {
+        method: 'GET',
+        params: { runId: 'run-1' },
+        query: {},
+        headers: {
+          authorization: 'Bearer abc',
+          cookie: 'forest_session_token=xyz',
+          'x-custom': 'should-not-leak',
+          'forest-secret-key': 'should-not-leak',
+        },
+      };
+      const res = fakeRes();
+
+      await get(req, res);
+
+      expect(scope.isDone()).toBe(true);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ ok: true });
+      teardown();
+    });
+  });
+
+  describe('lazy mount', () => {
+    const fakeLogger = { error: jest.fn() };
+
+    it('does not register any route when workflowExecutorUrl is not set', () => {
+      const fakeApp = { get: jest.fn(), post: jest.fn() };
+      initWorkflowExecutorRoutes(fakeApp, {}, { logger: fakeLogger });
+      expect(fakeApp.get).not.toHaveBeenCalled();
+      expect(fakeApp.post).not.toHaveBeenCalled();
+    });
+
+    it('registers exactly two routes when workflowExecutorUrl is set', () => {
+      const fakeApp = { get: jest.fn(), post: jest.fn() };
+      initWorkflowExecutorRoutes(
+        fakeApp,
+        { workflowExecutorUrl: executorBase },
+        { logger: fakeLogger },
+      );
+      expect(fakeApp.get).toHaveBeenCalledTimes(1);
+      expect(fakeApp.post).toHaveBeenCalledTimes(1);
+      expect(fakeApp.get.mock.calls[0][0]).toBe('/forest/_internal/workflow-executions/:runId');
+      expect(fakeApp.post.mock.calls[0][0]).toBe('/forest/_internal/workflow-executions/:runId/trigger');
+    });
+  });
+});

--- a/test/routes/workflow-executor.test.js
+++ b/test/routes/workflow-executor.test.js
@@ -13,12 +13,15 @@ function mockEnsureAuthenticated() {
   jest.spyOn(auth, 'ensureAuthenticated').mockImplementation((req, res, next) => next());
 }
 
-function teardown() {
-  jest.clearAllMocks();
-  nock.cleanAll();
-}
-
 describe('routes > workflow executor proxy', () => {
+  // NOTICE: Run teardown unconditionally so a failed assertion cannot leak a nock
+  //         interceptor or a mock into the next test.
+  // eslint-disable-next-line jest/no-hooks
+  afterEach(() => {
+    jest.clearAllMocks();
+    nock.cleanAll();
+  });
+
   describe('get /forest/_internal/workflow-executions/:runId', () => {
     it('forwards GET to executor /runs/:runId with query params', async () => {
       mockEnsureAuthenticated();
@@ -34,7 +37,6 @@ describe('routes > workflow executor proxy', () => {
       expect(response.status).toBe(200);
       expect(response.body).toStrictEqual({ id: 'run-123', state: 'pending' });
       expect(scope.isDone()).toBe(true);
-      teardown();
     });
 
     it('forwards a 4xx executor response verbatim', async () => {
@@ -47,7 +49,6 @@ describe('routes > workflow executor proxy', () => {
 
       expect(response.status).toBe(422);
       expect(response.body).toStrictEqual({ error: 'invalid_step' });
-      teardown();
     });
 
     it('returns 503 when the executor is unreachable', async () => {
@@ -62,7 +63,6 @@ describe('routes > workflow executor proxy', () => {
 
       expect(response.status).toBe(503);
       expect(response.body).toStrictEqual({ error: 'workflow_executor_unreachable' });
-      teardown();
     });
   });
 
@@ -81,7 +81,6 @@ describe('routes > workflow executor proxy', () => {
       expect(response.status).toBe(200);
       expect(response.body).toStrictEqual({ ok: true });
       expect(scope.isDone()).toBe(true);
-      teardown();
     });
   });
 
@@ -143,7 +142,6 @@ describe('routes > workflow executor proxy', () => {
       expect(scope.isDone()).toBe(true);
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith({ ok: true });
-      teardown();
     });
   });
 


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add workflow executor proxy routes for forwarding requests to a configured executor
- Adds [src/routes/workflow-executor.js](https://github.com/ForestAdmin/forest-express/pull/1058/files#diff-6b172fbe49f428449c9d9e08b79754ed108880ed5d174d9bfc9352a179a987ef) which mounts two authenticated routes (`GET` and `POST /forest/_internal/workflow-executions/:runId`) when `workflowExecutorUrl` is set in liana options.
- Proxies requests to the upstream executor at `/runs/:runId`, forwarding method, query params, JSON body (non-GET), and only `authorization`/`cookie` headers.
- Returns the executor's status and JSON body on success, mirrors upstream HTTP errors, and returns 503 with `{ error: 'workflow_executor_unreachable' }` on connection failures.
- Routes are not mounted when `workflowExecutorUrl` is absent, making the feature opt-in.

<!-- Macroscope's changelog starts here -->
#### Changes since #1058 opened

- Added timeout configuration to workflow executor proxy handler [893f378]
- Refactored test cleanup to use Jest lifecycle hook [893f378]
<!-- Macroscope's changelog ends here -->

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36e9417.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->