### PR TITLE
fix(composite-pk): normalize fields[] query param to comma-separated string [PRD-462]

### DIFF
--- a/src/deserializers/params-fields.js
+++ b/src/deserializers/params-fields.js
@@ -2,7 +2,23 @@ function ParamsFieldsDeserializer(paramsFields) {
   this.perform = () => {
     if (paramsFields) {
       return Object.keys(paramsFields).reduce((fields, modelName) => {
-        fields[modelName] = paramsFields[modelName].split(',');
+        const value = paramsFields[modelName];
+
+        if (Array.isArray(value)) {
+          // NOTICE: Some callers (e.g. collections with a composite primary key
+          //         requested through the workflow executor) serialize fields as
+          //         `fields[model][]=a&fields[model][]=b`, which qs parses into an
+          //         array instead of a comma-separated string. Entries may still
+          //         contain commas, so re-split and flatten them.
+          fields[modelName] = value.flatMap((entry) =>
+            (typeof entry === 'string' ? entry.split(',') : entry));
+        } else if (typeof value === 'string') {
+          fields[modelName] = value.split(',');
+        } else {
+          // NOTICE: Unexpected shape: keep as-is rather than throwing.
+          fields[modelName] = value;
+        }
+
         return fields;
       }, {});
     }

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ const SchemaSerializer = require('./serializers/schema');
 const Integrator = require('./integrations');
 const { getJWTConfiguration } = require('./config/jwt');
 const initAuthenticationRoutes = require('./routes/authentication');
+const normalizeQueryFields = require('./middlewares/query-fields-normalizer');
 
 const {
   logger,
@@ -274,6 +275,10 @@ exports.init = async (Implementation) => {
 
   // Mime type
   app.use(pathMounted, bodyParser.json());
+
+  // NOTICE: Normalize `fields[collection]` query params (array -> comma-separated string)
+  //         before any route handler or ORM adapter consumes request.query.
+  app.use(pathMounted, normalizeQueryFields);
 
   // Authentication
   if (configStore.lianaOptions.authSecret) {

--- a/src/middlewares/query-fields-normalizer.js
+++ b/src/middlewares/query-fields-normalizer.js
@@ -1,0 +1,25 @@
+// NOTICE: The `fields[collection]` query parameter is documented as a comma-separated
+//         string (e.g. `fields[book]=id,title`). Some clients (such as collections with
+//         a composite primary key requested through the workflow executor) serialize it
+//         as `fields[collection][]=a&fields[collection][]=b`, which the query parser turns
+//         into an array. Downstream consumers — both forest-express serializers and the
+//         ORM adapters (forest-express-sequelize / -mongoose) which read the same
+//         `request.query` reference — expect a string and call `.split(',')` on it,
+//         crashing on arrays. We normalize arrays back to the documented comma-separated
+//         form once, at the HTTP boundary, so every consumer receives the expected shape.
+function normalizeQueryFields(request, response, next) {
+  const fields = request.query && request.query.fields;
+
+  if (fields && typeof fields === 'object' && !Array.isArray(fields)) {
+    Object.keys(fields).forEach((collection) => {
+      const value = fields[collection];
+      if (Array.isArray(value)) {
+        fields[collection] = value.join(',');
+      }
+    });
+  }
+
+  next();
+}
+
+module.exports = normalizeQueryFields;

--- a/test/deserializers/params-fields.test.js
+++ b/test/deserializers/params-fields.test.js
@@ -8,4 +8,24 @@ describe('deserializers > params-fields', () => {
 
     expect(actualResult).toStrictEqual(expectedResult);
   });
+
+  it('should keep already-array values (e.g. composite primary keys)', () => {
+    const paramsFields = { dailySpecials: ['dayOfWeek', 'restaurantId'] };
+    const expectedResult = { dailySpecials: ['dayOfWeek', 'restaurantId'] };
+    const actualResult = (new ParamsFieldsDeserializer(paramsFields)).perform();
+
+    expect(actualResult).toStrictEqual(expectedResult);
+  });
+
+  it('should re-split and flatten comma separated entries inside an array', () => {
+    const paramsFields = { model: ['field1,field2', 'field3'] };
+    const expectedResult = { model: ['field1', 'field2', 'field3'] };
+    const actualResult = (new ParamsFieldsDeserializer(paramsFields)).perform();
+
+    expect(actualResult).toStrictEqual(expectedResult);
+  });
+
+  it('should return null when paramsFields is not provided', () => {
+    expect((new ParamsFieldsDeserializer(undefined)).perform()).toBeNull();
+  });
 });

--- a/test/middlewares/query-fields-normalizer.test.js
+++ b/test/middlewares/query-fields-normalizer.test.js
@@ -1,0 +1,42 @@
+const normalizeQueryFields = require('../../src/middlewares/query-fields-normalizer');
+
+function run(query) {
+  const request = { query };
+  const next = jest.fn();
+  normalizeQueryFields(request, {}, next);
+  return { request, next };
+}
+
+describe('middlewares > query-fields-normalizer', () => {
+  it('joins array field values into a comma-separated string', () => {
+    const { request, next } = run({ fields: { dailySpecials: ['dayOfWeek', 'restaurantId'] } });
+
+    expect(request.query.fields).toStrictEqual({ dailySpecials: 'dayOfWeek,restaurantId' });
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves comma-separated string values untouched', () => {
+    const { request } = run({ fields: { book: 'id,title', author: 'name' } });
+
+    expect(request.query.fields).toStrictEqual({ book: 'id,title', author: 'name' });
+  });
+
+  it('normalizes only array values within a mixed fields object', () => {
+    const { request } = run({ fields: { book: 'id,title', specials: ['a', 'b'] } });
+
+    expect(request.query.fields).toStrictEqual({ book: 'id,title', specials: 'a,b' });
+  });
+
+  it('does nothing when there is no fields param', () => {
+    const { request, next } = run({ search: 'foo' });
+
+    expect(request.query).toStrictEqual({ search: 'foo' });
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when query is empty', () => {
+    const { next } = run({});
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

On collections with a **composite primary key** requested through the **workflow executor**, `getData` (list) crashes with `TypeError: ... .split is not a function`:

- `forest-express` → `ParamsFieldsDeserializer`
- `forest-express-sequelize` → `requested-fields-extractor` (reads the same `request.query` reference)

### Root cause

The `fields[collection]` query param is documented as a **comma-separated string** (`fields[book]=id,title`). For composite-PK collections the workflow executor serializes it so that `qs` parses it into an **array** (e.g. `{ dailySpecials: ['dayOfWeek','restaurantId'] }`). Both consumers call `.split(',')` on it → crash. The browser path is unaffected (frontend sends the CSV form).

## Fix

Normalize once at the HTTP boundary so every downstream consumer — forest-express serializers **and** the ORM adapter (via the shared `request.query` reference) — receives the documented CSV shape, without patching forest-express-sequelize:

- **`src/middlewares/query-fields-normalizer.js`** (new): joins each `fields[x]` array → comma-separated string, mounted in `src/index.js` right after `bodyParser.json()`.
- **`src/deserializers/params-fields.js`**: tolerate array values (defense in depth for programmatic / exposed-service paths).
- Tests: middleware (5 cases) + deserializer (4 cases). Lint OK.

## Tickets

- Fixes [PRD-462](https://linear.app/forestadmin/issue/PRD-462)
- Related to [PRD-450](https://linear.app/forestadmin/issue/PRD-450) (composite-PK order/format for the executor). **Distinct bug**: PRD-450's forest-express twin is the composite *record-id format* (`parse_composite_id`, pipe vs JSON); this PR is the *field-selection param shape* (`fields[]` array vs CSV).

## Test plan

- [x] Unit tests green + lint
- [ ] E2E: executor `getData` on a composite-PK collection (e.g. `dailySpecials`) → no more `.split is not a function`; browser list still OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `fields[]` query param array normalization in composite PK requests
> - Adds a new [`query-fields-normalizer`](https://github.com/ForestAdmin/forest-express/pull/1059/files#diff-8152a89d93338450132d36e518d0adb382bfcd5a8f70442db5b9bf1cc89bb937) middleware that converts `fields[collection][]` array values into comma-separated strings before downstream handlers run.
> - Updates [`ParamsFieldsDeserializer.perform`](https://github.com/ForestAdmin/forest-express/pull/1059/files#diff-b9c44ef06fefeaf9699d8951b3f03336410e86459d23fd8443f4caa6ec73ccd3) to handle array inputs by flattening comma-separated entries, rather than unconditionally calling `.split(',')` which threw on non-string values.
> - The normalizer middleware is mounted in [`src/index.js`](https://github.com/ForestAdmin/forest-express/pull/1059/files#diff-bfe9874d239014961b1ae4e89875a6155667db834a410aaaa2ebe3cf89820556) before authentication and route handlers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ad08adf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->