### PR TITLE
feat(agent): forward workflow executor routes generically [PRD-567]

### DIFF
--- a/src/routes/workflow-executor.js
+++ b/src/routes/workflow-executor.js
@@ -3,43 +3,72 @@ const superagent = require('superagent');
 const path = require('../services/path');
 const auth = require('../services/auth');
 
-const FORWARDED_REQUEST_HEADERS = ['authorization', 'cookie'];
+const EXECUTOR_PREFIX = '/runs';
+// Hop-by-hop / client-recomputed headers — never forwarded (request or response side).
+const SKIPPED_HEADERS = new Set([
+  'connection', 'keep-alive', 'transfer-encoding', 'upgrade', 'te', 'trailer',
+  'proxy-authenticate', 'proxy-authorization', 'host', 'content-length',
+]);
+const UNSAFE_PATH_FRAGMENTS = ['..', '%2e', '%2E', '\\', '\0'];
 
 // NOTICE: Bound the proxied request so a hanging executor cannot tie up the
 //         connection indefinitely. A timeout raises an error without `.response`,
 //         so it falls through to the 503 branch.
-const REQUEST_TIMEOUT = { response: 30000, deadline: 60000 };
+const REQUEST_TIMEOUT = { response: 120000, deadline: 120000 };
 
-function pickForwardedHeaders(requestHeaders) {
+function forwardedRequestHeaders(requestHeaders) {
   const headers = {};
-  FORWARDED_REQUEST_HEADERS.forEach((name) => {
-    const value = requestHeaders[name];
-    if (value) {
+  Object.entries(requestHeaders).forEach(([name, value]) => {
+    if (value !== undefined && !SKIPPED_HEADERS.has(name.toLowerCase())) {
       headers[name] = value;
     }
   });
   return headers;
 }
 
-function buildHandler({ baseUrl, suffix, logger }) {
+function copyResponseHeaders(upstream, response) {
+  Object.entries(upstream.headers || {}).forEach(([name, value]) => {
+    if (value !== undefined && !SKIPPED_HEADERS.has(name.toLowerCase())) {
+      response.set(name, value);
+    }
+  });
+}
+
+// Security boundary: the wildcard can only map into EXECUTOR_PREFIX; reject anything that could
+// escape it, so non-/runs executor routes stay unreachable through the proxy.
+function executorPath(wildcard) {
+  if (!wildcard
+    || wildcard.startsWith('/')
+    || UNSAFE_PATH_FRAGMENTS.some((fragment) => wildcard.includes(fragment))) {
+    return null;
+  }
+  return `${EXECUTOR_PREFIX}/${wildcard}`;
+}
+
+function buildHandler({ baseUrl, logger }) {
   const normalizedBase = baseUrl.replace(/\/+$/, '');
 
   return async (request, response) => {
-    const url = `${normalizedBase}/runs/${request.params.runId}${suffix}`;
+    const suffix = executorPath(request.params[0]);
+    if (suffix === null) return response.status(404).json({ error: 'not_found' });
+
+    const url = `${normalizedBase}${suffix}`;
     const method = request.method.toLowerCase();
 
     try {
       let outgoing = superagent[method](url)
         .timeout(REQUEST_TIMEOUT)
-        .set(pickForwardedHeaders(request.headers));
+        .set(forwardedRequestHeaders(request.headers));
       if (request.query) outgoing = outgoing.query(request.query);
       if (method !== 'get' && request.body !== undefined) {
         outgoing = outgoing.send(request.body);
       }
       const upstream = await outgoing;
+      copyResponseHeaders(upstream, response);
       return response.status(upstream.status).json(upstream.body);
     } catch (error) {
       if (error.response) {
+        copyResponseHeaders(error.response, response);
         return response.status(error.response.status).json(error.response.body);
       }
       logger.error('[forest-express] workflow executor proxy error: ', error.message);
@@ -48,19 +77,15 @@ function buildHandler({ baseUrl, suffix, logger }) {
   };
 }
 
+// Catch-all: forward any verb/sub-path to EXECUTOR_PREFIX so a new executor route needs no change
+// here (PRD-567).
 function initWorkflowExecutorRoutes(app, opts, { logger }) {
   if (!opts.workflowExecutorUrl) return;
 
-  app.get(
-    path.generate('_internal/workflow-executions/:runId', opts),
+  app.all(
+    path.generate('_internal/workflow-executions/*', opts),
     auth.ensureAuthenticated,
-    buildHandler({ baseUrl: opts.workflowExecutorUrl, suffix: '', logger }),
-  );
-
-  app.post(
-    path.generate('_internal/workflow-executions/:runId/trigger', opts),
-    auth.ensureAuthenticated,
-    buildHandler({ baseUrl: opts.workflowExecutorUrl, suffix: '/trigger', logger }),
+    buildHandler({ baseUrl: opts.workflowExecutorUrl, logger }),
   );
 }
 

--- a/src/routes/workflow-executor.js
+++ b/src/routes/workflow-executor.js
@@ -4,10 +4,13 @@ const path = require('../services/path');
 const auth = require('../services/auth');
 
 const EXECUTOR_PREFIX = '/runs';
-// Hop-by-hop / client-recomputed headers — never forwarded (request or response side).
+// Never forwarded (request or response): hop-by-hop, Host, and body-framing headers.
+// res.json() re-serializes the body, so upstream length/encoding no longer match — and
+// forwarding accept-encoding would relay an encoding the re-emitted body doesn't use.
 const SKIPPED_HEADERS = new Set([
   'connection', 'keep-alive', 'transfer-encoding', 'upgrade', 'te', 'trailer',
-  'proxy-authenticate', 'proxy-authorization', 'host', 'content-length',
+  'proxy-authenticate', 'proxy-authorization', 'host',
+  'content-length', 'content-encoding', 'accept-encoding',
 ]);
 const UNSAFE_PATH_FRAGMENTS = ['..', '%2e', '%2E', '\\', '\0'];
 

--- a/test/routes/workflow-executor.test.js
+++ b/test/routes/workflow-executor.test.js
@@ -1,5 +1,6 @@
 const nock = require('nock');
 const request = require('supertest');
+const zlib = require('zlib');
 
 const createServer = require('../helpers/create-server');
 const auth = require('../../src/services/auth');
@@ -151,13 +152,17 @@ describe('routes > workflow executor proxy', () => {
       expect(res.status).toHaveBeenCalledWith(200);
     });
 
-    it('forwards executor response headers except hop-by-hop ones', async () => {
+    it('forwards executor response headers except hop-by-hop / encoding ones', async () => {
       const handler = captureHandler();
+      // gzipped body + content-type so superagent actually decompresses it. The proxy then
+      // re-emits plain JSON via res.json(), so it must NOT relay the upstream content-encoding.
+      const gzipped = zlib.gzipSync(JSON.stringify({ ok: true }));
       nock(executorBase)
         .get('/runs/run-1')
-        .reply(200, { ok: true }, {
+        .reply(200, gzipped, {
+          'content-type': 'application/json',
+          'content-encoding': 'gzip',
           'x-executor-custom': 'passthrough-value',
-          'transfer-encoding': 'chunked',
         });
 
       const req = {
@@ -167,8 +172,29 @@ describe('routes > workflow executor proxy', () => {
 
       await handler(req, res);
 
+      // Body was decoded and re-emitted as plain JSON...
+      expect(res.json).toHaveBeenCalledWith({ ok: true });
       expect(res.set).toHaveBeenCalledWith('x-executor-custom', 'passthrough-value');
-      expect(res.set).not.toHaveBeenCalledWith('transfer-encoding', expect.anything());
+      // ...so the upstream content-encoding must not be relayed onto plain bytes.
+      expect(res.set).not.toHaveBeenCalledWith('content-encoding', expect.anything());
+    });
+
+    it('does not forward the client accept-encoding (superagent manages its own)', async () => {
+      const handler = captureHandler();
+      // A forwarded client value would override superagent's own header; assert it doesn't.
+      const scope = nock(executorBase)
+        .matchHeader('accept-encoding', (value) => value !== 'identity')
+        .get('/runs/run-1')
+        .reply(200, { ok: true });
+
+      const req = {
+        method: 'GET', params: { 0: 'run-1' }, query: {}, headers: { 'accept-encoding': 'identity' },
+      };
+      const res = fakeRes();
+
+      await handler(req, res);
+
+      expect(scope.isDone()).toBe(true);
     });
   });
 

--- a/test/routes/workflow-executor.test.js
+++ b/test/routes/workflow-executor.test.js
@@ -22,8 +22,8 @@ describe('routes > workflow executor proxy', () => {
     nock.cleanAll();
   });
 
-  describe('get /forest/_internal/workflow-executions/:runId', () => {
-    it('forwards GET to executor /runs/:runId with query params', async () => {
+  describe('generic forwarding', () => {
+    it('forwards GET under /runs with query params, returning the executor response', async () => {
       mockEnsureAuthenticated();
       const app = await createServer(envSecret, authSecret, { workflowExecutorUrl: executorBase });
       const scope = nock(executorBase)
@@ -36,6 +36,35 @@ describe('routes > workflow executor proxy', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toStrictEqual({ id: 'run-123', state: 'pending' });
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('forwards POST trigger with the JSON body to /runs/:runId/trigger', async () => {
+      mockEnsureAuthenticated();
+      const app = await createServer(envSecret, authSecret, { workflowExecutorUrl: executorBase });
+      const scope = nock(executorBase)
+        .post('/runs/run-42/trigger', { step: 'approve', value: 42 })
+        .reply(200, { ok: true });
+
+      const response = await request(app)
+        .post('/forest/_internal/workflow-executions/run-42/trigger')
+        .send({ step: 'approve', value: 42 });
+
+      expect(response.status).toBe(200);
+      expect(response.body).toStrictEqual({ ok: true });
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('forwards any verb and any future sub-path without a dedicated route', async () => {
+      mockEnsureAuthenticated();
+      const app = await createServer(envSecret, authSecret, { workflowExecutorUrl: executorBase });
+      const scope = nock(executorBase).delete('/runs/run-123/cancel').reply(200, { cancelled: true });
+
+      const response = await request(app)
+        .delete('/forest/_internal/workflow-executions/run-123/cancel');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toStrictEqual({ cancelled: true });
       expect(scope.isDone()).toBe(true);
     });
 
@@ -66,82 +95,116 @@ describe('routes > workflow executor proxy', () => {
     });
   });
 
-  describe('post /forest/_internal/workflow-executions/:runId/trigger', () => {
-    it('forwards POST with the JSON body to executor /runs/:runId/trigger', async () => {
-      mockEnsureAuthenticated();
-      const app = await createServer(envSecret, authSecret, { workflowExecutorUrl: executorBase });
-      const scope = nock(executorBase)
-        .post('/runs/run-42/trigger', { step: 'approve', value: 42 })
-        .reply(200, { ok: true });
-
-      const response = await request(app)
-        .post('/forest/_internal/workflow-executions/run-42/trigger')
-        .send({ step: 'approve', value: 42 });
-
-      expect(response.status).toBe(200);
-      expect(response.body).toStrictEqual({ ok: true });
-      expect(scope.isDone()).toBe(true);
-    });
-  });
-
   describe('header forwarding', () => {
     // The test helper's express-jwt layer can't accept tokens signed with the
     // agent's authSecret, so we exercise the handler directly: capture it via
     // a fake express app and invoke it with a mock req/res.
-    function captureHandlers() {
-      const captured = {};
-      const fakeApp = {
-        get: jest.fn((_path, _auth, handler) => { captured.get = handler; }),
-        post: jest.fn((_path, _auth, handler) => { captured.post = handler; }),
-      };
+    function captureHandler() {
+      let handler;
+      const fakeApp = { all: jest.fn((_path, _auth, fn) => { handler = fn; }) };
       initWorkflowExecutorRoutes(
         fakeApp,
         { workflowExecutorUrl: executorBase },
         { logger: { error: jest.fn() } },
       );
-      return captured;
+      return handler;
     }
 
     function fakeRes() {
-      const res = {
-        status: jest.fn(),
-        json: jest.fn(),
-      };
+      const res = { status: jest.fn(), json: jest.fn(), set: jest.fn() };
       res.status.mockReturnValue(res);
       res.json.mockReturnValue(res);
+      res.set.mockReturnValue(res);
       return res;
     }
 
-    it('forwards only Authorization and Cookie headers to the executor', async () => {
-      const { get } = captureHandlers();
+    it('forwards all client headers except hop-by-hop / host / content-length', async () => {
+      const handler = captureHandler();
       const scope = nock(executorBase, {
         reqheaders: {
           authorization: 'Bearer abc',
           cookie: 'forest_session_token=xyz',
+          'x-custom': 'forwarded',
         },
-        badheaders: ['x-custom', 'forest-secret-key'],
+        badheaders: ['te', 'host'],
       })
         .get('/runs/run-1')
         .reply(200, { ok: true });
 
       const req = {
         method: 'GET',
-        params: { runId: 'run-1' },
+        params: { 0: 'run-1' },
         query: {},
         headers: {
           authorization: 'Bearer abc',
           cookie: 'forest_session_token=xyz',
-          'x-custom': 'should-not-leak',
-          'forest-secret-key': 'should-not-leak',
+          'x-custom': 'forwarded',
+          te: 'trailers',
+          host: 'agent.test',
         },
       };
       const res = fakeRes();
 
-      await get(req, res);
+      await handler(req, res);
 
       expect(scope.isDone()).toBe(true);
       expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith({ ok: true });
+    });
+
+    it('forwards executor response headers except hop-by-hop ones', async () => {
+      const handler = captureHandler();
+      nock(executorBase)
+        .get('/runs/run-1')
+        .reply(200, { ok: true }, {
+          'x-executor-custom': 'passthrough-value',
+          'transfer-encoding': 'chunked',
+        });
+
+      const req = {
+        method: 'GET', params: { 0: 'run-1' }, query: {}, headers: {},
+      };
+      const res = fakeRes();
+
+      await handler(req, res);
+
+      expect(res.set).toHaveBeenCalledWith('x-executor-custom', 'passthrough-value');
+      expect(res.set).not.toHaveBeenCalledWith('transfer-encoding', expect.anything());
+    });
+  });
+
+  describe('path traversal protection (the namespace security boundary)', () => {
+    function captureHandler() {
+      let handler;
+      const fakeApp = { all: jest.fn((_path, _auth, fn) => { handler = fn; }) };
+      initWorkflowExecutorRoutes(
+        fakeApp,
+        { workflowExecutorUrl: executorBase },
+        { logger: { error: jest.fn() } },
+      );
+      return handler;
+    }
+
+    it.each([
+      '..',
+      '../mcp-oauth-credentials',
+      'run-123/../../mcp-oauth-credentials',
+      '%2e%2e/mcp-oauth-credentials',
+    ])('rejects %p with 404 and never forwards', async (evilPath) => {
+      const handler = captureHandler();
+      const scope = nock(executorBase).get(/.*/).reply(200, {});
+
+      const req = {
+        method: 'GET', params: { 0: evilPath }, query: {}, headers: {},
+      };
+      const res = { status: jest.fn(), json: jest.fn() };
+      res.status.mockReturnValue(res);
+      res.json.mockReturnValue(res);
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(scope.isDone()).toBe(false);
+      nock.cleanAll();
     });
   });
 
@@ -149,23 +212,20 @@ describe('routes > workflow executor proxy', () => {
     const fakeLogger = { error: jest.fn() };
 
     it('does not register any route when workflowExecutorUrl is not set', () => {
-      const fakeApp = { get: jest.fn(), post: jest.fn() };
+      const fakeApp = { all: jest.fn() };
       initWorkflowExecutorRoutes(fakeApp, {}, { logger: fakeLogger });
-      expect(fakeApp.get).not.toHaveBeenCalled();
-      expect(fakeApp.post).not.toHaveBeenCalled();
+      expect(fakeApp.all).not.toHaveBeenCalled();
     });
 
-    it('registers exactly two routes when workflowExecutorUrl is set', () => {
-      const fakeApp = { get: jest.fn(), post: jest.fn() };
+    it('registers a single catch-all route when workflowExecutorUrl is set', () => {
+      const fakeApp = { all: jest.fn() };
       initWorkflowExecutorRoutes(
         fakeApp,
         { workflowExecutorUrl: executorBase },
         { logger: fakeLogger },
       );
-      expect(fakeApp.get).toHaveBeenCalledTimes(1);
-      expect(fakeApp.post).toHaveBeenCalledTimes(1);
-      expect(fakeApp.get.mock.calls[0][0]).toBe('/forest/_internal/workflow-executions/:runId');
-      expect(fakeApp.post.mock.calls[0][0]).toBe('/forest/_internal/workflow-executions/:runId/trigger');
+      expect(fakeApp.all).toHaveBeenCalledTimes(1);
+      expect(fakeApp.all.mock.calls[0][0]).toBe('/forest/_internal/workflow-executions/*');
     });
   });
 });


### PR DESCRIPTION
## What

4th runtime of PRD-567 (Node v1 liana, `forest-express`). Replaces the two explicit `show`/`trigger` proxy routes with a **single catch-all** that forwards every verb and sub-path under `/_internal/workflow-executions/*` to the executor `/runs` namespace. The agent no longer needs a change when the executor adds a route.

Mirrors the other three runtimes:
- Node core ([agent-nodejs#1666](https://github.com/ForestAdmin/agent-nodejs/pull/1666))
- Ruby v2 ([agent-ruby#319](https://github.com/ForestAdmin/agent-ruby/pull/319))
- Ruby v1 liana ([forest-rails#777](https://github.com/ForestAdmin/forest-rails/pull/777))

## Changes

- **Catch-all route** (`app.all('.../*')`) replacing the 2 per-route entries — all verbs.
- **Forward all request headers** except hop-by-hop / host / content-length (was an `authorization`+`cookie` whitelist).
- **Forward all response headers** except hop-by-hop — so executor-set headers (e.g. the version gate) survive the proxy.
- **Single large timeout** (no per-route values).
- **Path-traversal guard**: the wildcard can only map into `/runs` — `..`, encoded dots, backslash, null byte and leading `/` are rejected with 404, keeping non-`/runs` executor routes unreachable through the proxy.

## Tests

Rewritten suite → generic forwarding (arbitrary verb/sub-path), request + response header filtering, **path-traversal security boundary**, status/error passthrough, lazy mount. **13/13 green**.

## Known limitation (by design)

This legacy liana is **JSON-only**: responses are normalized to JSON (`res.json(...)`). A hypothetical non-JSON executor response (e.g. `text/plain`) would not pass through verbatim. The executor only returns JSON today, so this does not affect the PRD-567 contract in practice; the modern `@forestadmin/agent` path (agent-nodejs#1666) handles raw passthrough.

fixes PRD-567

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace fixed workflow executor routes with a catch-all proxy for all verbs and sub-paths
> - Replaces two explicit routes (`GET /:runId` and `POST /:runId/trigger`) with a single `app.all('/_internal/workflow-executions/*', ...)` that proxies any HTTP method and sub-path to the workflow executor.
> - Broadens header forwarding: outgoing requests now include all client headers except hop-by-hop, `Host`, and encoding/framing headers; executor response headers are relayed back to the client under the same exclusion rules.
> - Adds path traversal protection via `executorPath()`, which rejects paths containing `..`, `%2e`, `\`, or null bytes with a 404.
> - Increases proxy timeouts from 30s/60s to 120s response/deadline in [workflow-executor.js](https://github.com/ForestAdmin/forest-express/pull/1060/files#diff-6b172fbe49f428449c9d9e08b79754ed108880ed5d174d9bfc9352a179a987ef).
>
> #### 🖇️ Linked Issues
> Implements [PRD-567](ticket:linear/PRD-567).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b96c512.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->