### PR TITLE
feat(agent): forward any executor route generically [PRD-567]

### DIFF
--- a/src/routes/workflow-executor.js
+++ b/src/routes/workflow-executor.js
@@ -3,7 +3,6 @@ const superagent = require('superagent');
 const path = require('../services/path');
 const auth = require('../services/auth');
 
-const EXECUTOR_PREFIX = '/runs';
 // Never forwarded (request or response): hop-by-hop, Host, and body-framing headers.
 // res.json() re-serializes the body, so upstream length/encoding no longer match — and
 // forwarding accept-encoding would relay an encoding the re-emitted body doesn't use.
@@ -37,29 +36,37 @@ function copyResponseHeaders(upstream, response) {
   });
 }
 
-// Security boundary: the wildcard can only map into EXECUTOR_PREFIX; reject anything that could
-// escape it, so non-/runs executor routes stay unreachable through the proxy.
+// First-pass rejection of escape attempts; returns null for anything that could leave the
+// executor origin (the authoritative origin check is in buildHandler).
 function executorPath(wildcard) {
   if (!wildcard
     || wildcard.startsWith('/')
     || UNSAFE_PATH_FRAGMENTS.some((fragment) => wildcard.includes(fragment))) {
     return null;
   }
-  return `${EXECUTOR_PREFIX}/${wildcard}`;
+  return `/${wildcard}`;
 }
 
 function buildHandler({ baseUrl, logger }) {
   const normalizedBase = baseUrl.replace(/\/+$/, '');
+  const baseOrigin = new URL(normalizedBase).origin;
 
   return async (request, response) => {
     const suffix = executorPath(request.params[0]);
     if (suffix === null) return response.status(404).json({ error: 'not_found' });
 
     const url = `${normalizedBase}${suffix}`;
+    // Authoritative SSRF check: the forwarded request must never leave the executor origin.
+    if (new URL(url).origin !== baseOrigin) {
+      return response.status(404).json({ error: 'not_found' });
+    }
     const method = request.method.toLowerCase();
 
     try {
       let outgoing = superagent[method](url)
+        // Don't follow redirects: a 3xx to an off-origin Location would bypass the origin guard
+        // (and matches the Node agent, whose raw http client never follows redirects).
+        .redirects(0)
         .timeout(REQUEST_TIMEOUT)
         .set(forwardedRequestHeaders(request.headers));
       if (request.query) outgoing = outgoing.query(request.query);
@@ -80,13 +87,13 @@ function buildHandler({ baseUrl, logger }) {
   };
 }
 
-// Catch-all: forward any verb/sub-path to EXECUTOR_PREFIX so a new executor route needs no change
-// here (PRD-567).
+// Catch-all: forward any verb/sub-path verbatim to the executor, so a new executor route needs
+// no change here.
 function initWorkflowExecutorRoutes(app, opts, { logger }) {
   if (!opts.workflowExecutorUrl) return;
 
   app.all(
-    path.generate('_internal/workflow-executions/*', opts),
+    path.generate('_internal/executor/*', opts),
     auth.ensureAuthenticated,
     buildHandler({ baseUrl: opts.workflowExecutorUrl, logger }),
   );

--- a/test/routes/workflow-executor.test.js
+++ b/test/routes/workflow-executor.test.js
@@ -24,7 +24,7 @@ describe('routes > workflow executor proxy', () => {
   });
 
   describe('generic forwarding', () => {
-    it('forwards GET under /runs with query params, returning the executor response', async () => {
+    it('forwards a run GET (caller includes runs/) with query params, returning the response', async () => {
       mockEnsureAuthenticated();
       const app = await createServer(envSecret, authSecret, { workflowExecutorUrl: executorBase });
       const scope = nock(executorBase)
@@ -33,14 +33,14 @@ describe('routes > workflow executor proxy', () => {
         .reply(200, { id: 'run-123', state: 'pending' });
 
       const response = await request(app)
-        .get('/forest/_internal/workflow-executions/run-123?foo=bar');
+        .get('/forest/_internal/executor/runs/run-123?foo=bar');
 
       expect(response.status).toBe(200);
       expect(response.body).toStrictEqual({ id: 'run-123', state: 'pending' });
       expect(scope.isDone()).toBe(true);
     });
 
-    it('forwards POST trigger with the JSON body to /runs/:runId/trigger', async () => {
+    it('forwards a POST trigger with the JSON body to /runs/:runId/trigger', async () => {
       mockEnsureAuthenticated();
       const app = await createServer(envSecret, authSecret, { workflowExecutorUrl: executorBase });
       const scope = nock(executorBase)
@@ -48,7 +48,7 @@ describe('routes > workflow executor proxy', () => {
         .reply(200, { ok: true });
 
       const response = await request(app)
-        .post('/forest/_internal/workflow-executions/run-42/trigger')
+        .post('/forest/_internal/executor/runs/run-42/trigger')
         .send({ step: 'approve', value: 42 });
 
       expect(response.status).toBe(200);
@@ -56,16 +56,18 @@ describe('routes > workflow executor proxy', () => {
       expect(scope.isDone()).toBe(true);
     });
 
-    it('forwards any verb and any future sub-path without a dedicated route', async () => {
+    it('forwards a non-runs route verbatim (no /runs prefix injected)', async () => {
       mockEnsureAuthenticated();
       const app = await createServer(envSecret, authSecret, { workflowExecutorUrl: executorBase });
-      const scope = nock(executorBase).delete('/runs/run-123/cancel').reply(200, { cancelled: true });
+      const scope = nock(executorBase)
+        .delete('/mcp-oauth-credentials')
+        .reply(200, { deleted: true });
 
       const response = await request(app)
-        .delete('/forest/_internal/workflow-executions/run-123/cancel');
+        .delete('/forest/_internal/executor/mcp-oauth-credentials');
 
       expect(response.status).toBe(200);
-      expect(response.body).toStrictEqual({ cancelled: true });
+      expect(response.body).toStrictEqual({ deleted: true });
       expect(scope.isDone()).toBe(true);
     });
 
@@ -75,7 +77,7 @@ describe('routes > workflow executor proxy', () => {
       nock(executorBase).get('/runs/run-456').reply(422, { error: 'invalid_step' });
 
       const response = await request(app)
-        .get('/forest/_internal/workflow-executions/run-456');
+        .get('/forest/_internal/executor/runs/run-456');
 
       expect(response.status).toBe(422);
       expect(response.body).toStrictEqual({ error: 'invalid_step' });
@@ -89,7 +91,7 @@ describe('routes > workflow executor proxy', () => {
         .replyWithError({ code: 'ECONNREFUSED', message: 'refused' });
 
       const response = await request(app)
-        .get('/forest/_internal/workflow-executions/run-789');
+        .get('/forest/_internal/executor/runs/run-789');
 
       expect(response.status).toBe(503);
       expect(response.body).toStrictEqual({ error: 'workflow_executor_unreachable' });
@@ -134,7 +136,7 @@ describe('routes > workflow executor proxy', () => {
 
       const req = {
         method: 'GET',
-        params: { 0: 'run-1' },
+        params: { 0: 'runs/run-1' },
         query: {},
         headers: {
           authorization: 'Bearer abc',
@@ -166,7 +168,7 @@ describe('routes > workflow executor proxy', () => {
         });
 
       const req = {
-        method: 'GET', params: { 0: 'run-1' }, query: {}, headers: {},
+        method: 'GET', params: { 0: 'runs/run-1' }, query: {}, headers: {},
       };
       const res = fakeRes();
 
@@ -188,7 +190,7 @@ describe('routes > workflow executor proxy', () => {
         .reply(200, { ok: true });
 
       const req = {
-        method: 'GET', params: { 0: 'run-1' }, query: {}, headers: { 'accept-encoding': 'identity' },
+        method: 'GET', params: { 0: 'runs/run-1' }, query: {}, headers: { 'accept-encoding': 'identity' },
       };
       const res = fakeRes();
 
@@ -198,7 +200,7 @@ describe('routes > workflow executor proxy', () => {
     });
   });
 
-  describe('path traversal protection (the namespace security boundary)', () => {
+  describe('guards against escaping the executor origin (SSRF)', () => {
     function captureHandler() {
       let handler;
       const fakeApp = { all: jest.fn((_path, _auth, fn) => { handler = fn; }) };
@@ -232,6 +234,29 @@ describe('routes > workflow executor proxy', () => {
       expect(scope.isDone()).toBe(false);
       nock.cleanAll();
     });
+
+    it('does not follow an executor redirect to an off-origin host', async () => {
+      const handler = captureHandler();
+      // Executor replies 3xx pointing off-origin; the proxy must NOT chase it.
+      nock(executorBase)
+        .get('/runs/run-1')
+        .reply(302, '', { Location: 'http://evil.com/stolen' });
+      const evil = nock('http://evil.com').get('/stolen').reply(200, { hacked: true });
+
+      const req = {
+        method: 'GET', params: { 0: 'runs/run-1' }, query: {}, headers: {},
+      };
+      const res = { status: jest.fn(), json: jest.fn(), set: jest.fn() };
+      res.status.mockReturnValue(res);
+      res.json.mockReturnValue(res);
+      res.set.mockReturnValue(res);
+
+      await handler(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(302); // 3xx returned to the client, not followed
+      expect(evil.isDone()).toBe(false); // never reached the off-origin host
+      nock.cleanAll();
+    });
   });
 
   describe('lazy mount', () => {
@@ -251,7 +276,7 @@ describe('routes > workflow executor proxy', () => {
         { logger: fakeLogger },
       );
       expect(fakeApp.all).toHaveBeenCalledTimes(1);
-      expect(fakeApp.all.mock.calls[0][0]).toBe('/forest/_internal/workflow-executions/*');
+      expect(fakeApp.all.mock.calls[0][0]).toBe('/forest/_internal/executor/*');
     });
   });
 });


### PR DESCRIPTION
## What

Ports the generic executor passthrough to forest-express (legacy Node liana), matching the agent-nodejs reference ([agent-nodejs#1707](https://github.com/ForestAdmin/agent-nodejs/pull/1707), released 1.81.0).

- **Single catch-all mount** `_internal/executor/*` → executor `/*` **verbatim** (all verbs). Replaces the `/runs`-confined proxy. Callers address runs as `runs/<id>`, so any executor route (mcp-oauth-credentials, future ones) is reachable with no agent change.

## Security

- **SSRF guard**: reject empty / leading-`/` / `..` / `%2e`/`%2E` / backslash / NUL, and verify the resolved URL never leaves the executor origin.
- **`.redirects(0)`**: don't follow executor redirects — a 3xx `Location` to an off-origin host can't make the agent reach another host (matches the Node agent's raw http client, which never follows redirects).

## Tests

**15/15**. Run GET (caller includes `runs/`), POST trigger, **non-runs route verbatim** (asserts no `/runs` prefix injected), 4xx passthrough, 503 unreachable, req/resp header filtering (gzip + accept-encoding), SSRF traversal vectors → 404, **redirect not followed**, lazy mount (`/forest/_internal/executor/*`).

## Note
Same design as Node, one safe nuance: a leading control-char (`\t//host`) is *forwarded* here (string-concat keeps the host fixed → executor 404s it) rather than rejected as in Node (`new URL` relative resolution) — both stay on the executor origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Forward arbitrary executor routes generically under `/forest/_internal/executor/*`
> - Changes the catch-all route from `/forest/_internal/workflow-executions/*` to `/forest/_internal/executor/*` in [workflow-executor.js](https://github.com/ForestAdmin/forest-express/pull/1061/files#diff-6b172fbe49f428449c9d9e08b79754ed108880ed5d174d9bfc9352a179a987ef).
> - Removes the automatic `/runs` prefix injection so sub-paths are forwarded verbatim; callers targeting run resources must now include `runs/` themselves.
> - Adds an SSRF guard that returns 404 if the constructed upstream URL's origin differs from the executor's base origin.
> - Behavioral Change: the proxy no longer follows upstream 3xx redirects — redirect responses are returned directly to the client.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fce90cd. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->