### PR TITLE
perf(ip-whitelist): build the BlockList once per refresh instead of per request [PRD-798]

### DIFF
--- a/src/services/ip-whitelist.js
+++ b/src/services/ip-whitelist.js
@@ -1,6 +1,5 @@
 const net = require('net');
 const P = require('bluebird');
-const _ = require('lodash');
 const VError = require('verror');
 const logger = require('./logger');
 const errorMessages = require('../utils/error-messages');
@@ -12,38 +11,43 @@ const RULE_TYPE_RANGE = 1;
 const RULE_TYPE_SUBNET = 2;
 
 let ipWhitelistRules = null;
+let ipWhitelistBlockList = null;
 let useIpWhitelist = true;
 
 function familyOf(ip) {
   return net.isIP(ip) === 6 ? 'ipv6' : 'ipv4';
 }
 
-function isIpMatchesRule(ip, rule) {
-  if (!net.isIP(ip)) return false;
-
-  try {
-    const blockList = new net.BlockList();
-    switch (rule.type) {
-      case RULE_TYPE_IP:
-        blockList.addAddress(rule.ip, familyOf(rule.ip));
-        break;
-      case RULE_TYPE_RANGE:
-        blockList.addRange(rule.ipMinimum, rule.ipMaximum, familyOf(rule.ipMinimum));
-        break;
-      case RULE_TYPE_SUBNET: {
-        const [address, prefix] = rule.range.split('/');
-        blockList.addSubnet(address, parseInt(prefix, 10), familyOf(address));
-        break;
-      }
-      default:
-        return false;
+function addRuleTo(blockList, rule) {
+  switch (rule.type) {
+    case RULE_TYPE_IP:
+      blockList.addAddress(rule.ip, familyOf(rule.ip));
+      break;
+    case RULE_TYPE_RANGE:
+      blockList.addRange(rule.ipMinimum, rule.ipMaximum, familyOf(rule.ipMinimum));
+      break;
+    case RULE_TYPE_SUBNET: {
+      const [address, prefix] = rule.range.split('/');
+      blockList.addSubnet(address, parseInt(prefix, 10), familyOf(address));
+      break;
     }
-
-    return blockList.check(ip, familyOf(ip));
-  } catch (error) {
-    logger.warn(`IP Whitelist: ignoring an invalid rule. ${error.message}`);
-    return false;
+    default:
+      break;
   }
+}
+
+function buildBlockList(rules) {
+  const blockList = new net.BlockList();
+
+  (rules || []).forEach((rule) => {
+    try {
+      addRuleTo(blockList, rule);
+    } catch (error) {
+      logger.warn(`IP Whitelist: ignoring an invalid rule. ${error.message}`);
+    }
+  });
+
+  return blockList;
 }
 
 function retrieve(environmentSecret) {
@@ -58,6 +62,7 @@ function retrieve(environmentSecret) {
     .then((ipWhitelistData) => {
       useIpWhitelist = ipWhitelistData.useIpWhitelist;
       ipWhitelistRules = ipWhitelistData.rules;
+      ipWhitelistBlockList = buildBlockList(ipWhitelistRules);
     })
     .catch((error) => {
       logger.error(`An error occured while retrieving your IP whitelist. Your Forest envSecret may be missing or unknown. Can you check that you properly set your Forest envSecret in the Forest initializer? ${error.message}`);
@@ -70,11 +75,10 @@ function isIpWhitelistRetrieved() {
 }
 
 function isIpValid(ip) {
-  if (useIpWhitelist) {
-    return _.some(ipWhitelistRules, (rule) => isIpMatchesRule(ip, rule));
-  }
+  if (!useIpWhitelist) return true;
+  if (!ipWhitelistBlockList || !net.isIP(ip)) return false;
 
-  return true;
+  return ipWhitelistBlockList.check(ip, familyOf(ip));
 }
 
 module.exports = {

--- a/test/services/ip-whitelist.test.js
+++ b/test/services/ip-whitelist.test.js
@@ -4,8 +4,10 @@ const {
   isIpWhitelistRetrieved,
 } = require('../../src/services/ip-whitelist');
 const forestServerRequester = require('../../src/services/forest-server-requester');
+const logger = require('../../src/services/logger');
 
 jest.mock('../../src/services/forest-server-requester');
+jest.mock('../../src/services/logger');
 
 describe('utils › services', () => {
   forestServerRequester.perform.mockResolvedValue({
@@ -121,6 +123,22 @@ describe('utils › services', () => {
       });
       await retrieve();
       expect(isIpValid('1.1.0.0')).toBe(true);
+    });
+
+    it('should report it once when the rules are refreshed, not on every check', async () => {
+      forestServerRequester.perform.mockResolvedValueOnce({
+        data: { attributes: { use_ip_whitelist: true, rules: [{ type: 2, range: '1.0.0.0' }] } },
+      });
+      logger.warn.mockClear();
+
+      await retrieve();
+
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+
+      isIpValid('1.0.0.0');
+      isIpValid('1.0.0.1');
+
+      expect(logger.warn).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
Fixes PRD-798

Follow-up optimization spun off from #1062, which replaced `forest-ip-utils` with the native `net` module.

`isIpMatchesRule` built a brand new `net.BlockList` on **every call**, and `isIpValid` called it **once per rule** via `_.some`. So each incoming request reconstructed one `BlockList` per whitelist rule, even though the rules only change when they are refreshed from the Forest server.

All rules now go into a single `BlockList` built in `retrieve`, and `isIpValid` reduces to one `blockList.check(ip, family)`. Per-request work becomes per-refresh work.

### On the ticket's coordination note

The ticket asked to coordinate with "the robustness fix raised in the PR review (skip invalid rules instead of throwing) so one bad rule doesn't poison the shared BlockList". That fix already landed with #1062 — `isIpMatchesRule` had a `try/catch` per rule. Aggregating into one list would have silently dropped that protection, so the `try/catch` moved to build time and now wraps each rule's insertion individually: one invalid rule is skipped, the others still apply. Covered by the pre-existing `should still evaluate valid rules when another rule is malformed`.

Side effect worth noting: an invalid rule used to be logged on **every request** (the `catch` sat on the hot path). It is now logged **once per refresh**.

### Behaviour preservation

Public API unchanged (`retrieve` / `isIpValid` / `isIpWhitelistRetrieved`); `isIpMatchesRule` was module-private and has no other caller in the repo. Each edge case maps 1:1 to the previous implementation:

| Case | Before | After |
| -- | -- | -- |
| whitelist disabled | `true` | `true` |
| rules never retrieved (`null`) | `_.some(null, …)` → `false` | no BlockList → `false` |
| empty rule set | `false` | empty BlockList → `false` |
| non-IP input | `false` | `false` |
| unknown rule type | that rule never matches, silently | idem (skipped at build, still silent) |
| invalid rule (throws) | that rule never matches, logged per request | idem, logged per refresh |

`lodash` is no longer needed in this module and its import was dropped.

### Tests

One test added, written first and red before the change: it asserts the invalid-rule warning fires once when the rules are refreshed and **not** on subsequent checks — i.e. it fails on the old implementation (0 warnings at refresh, then one per check) and passes on the new one. It is the observable expression of "per-request work became per-refresh work".

- `test/services/ip-whitelist.test.js`: 11/11, including the 10 pre-existing behaviour tests untouched.
- Full suite: **55 suites, 414 passed, 2 todo, 0 failed**.
- ESLint clean.

## Definition of Done

### General

- [x] Write an explicit title for the Pull Request, following [Conventional Commits specification](https://www.conventionalcommits.org)
- [ ] Test manually the implemented changes — covered by the unit suite (every rule type, both IP families, and the malformed-rule paths); not exercised against a live agent
- [x] Validate the code quality (indentation, syntax, style, simplicity, readability)

### Security

- [x] Consider the security impact of the changes made — this code is an access-control gate, so the risk is a rule silently ceasing to apply. That is exactly what the preserved per-rule `try/catch` and the unchanged behaviour table above guard against; the 10 pre-existing tests cover each rule type and the malformed cases. No change to what is accepted or rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Build `net.BlockList` once per refresh instead of per request in ip-whitelist service
> - Previously, `isIpMatchesRule` constructed a new `net.BlockList` for every rule on every IP check; now a single `BlockList` is built and cached in `buildBlockList` when `retrieve` fetches new rules.
> - Invalid rules are logged once at retrieval time via `addRuleTo`; subsequent calls to `isIpValid` skip per-rule evaluation entirely.
> - `isIpValid` returns `false` immediately if the cached block list is unavailable or the IP is syntactically invalid.
> - Behavioral Change: validation now fails closed (returns `false`) if `retrieve` has not yet been called or failed, rather than evaluating rules inline.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 40805da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->